### PR TITLE
Add support GitHub Action and Makefile for running tests

### DIFF
--- a/.github/workflows/openshift-tests.yaml
+++ b/.github/workflows/openshift-tests.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   openshift-tests:
     # This job only runs for '[test]' pull request comments by owner, member
-    name: "integration tests: RHEL-8 OpenShift 4"
+    name: "Integration tests for our Helm charts tested on RHEL-8 OpenShift 4"
     runs-on: ubuntu-20.04
 
     if: |
@@ -18,14 +18,14 @@ jobs:
         with:
           ref: "refs/pull/${{ github.event.issue.number }}/head"
 
-      - name: Schedule tests for RHEL 8
+      - name: Schedule tests on external Testing Farm by Testing-Farm-as-github-action
         uses: sclorg/testing-farm-as-github-action@v1
         with:
           api_key:  ${{ secrets.TF_INTERNAL_API_KEY }}
           compose:  "RHEL-8.6.0-Nightly"
           git_url:  "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
-          git_ref:  "main"
+          git_ref:  "master"
           tf_scope: "private"
-          tmt_plan_regex: "rhel8-openshift-4"
-          pull_request_status_name: "RHEL8 - OpenShift 4"
-          variables: "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;REPO_NAME=$GITHUB_REPOSITORY;PR_NUMBER=${{ github.event.issue.number }}"
+          tmt_plan_regex: "helm-charts"
+          pull_request_status_name: "Helm charts"
+          variables: "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;REPO_NAME=$GITHUB_REPOSITORY;PR_NUMBER=${{ github.event.issue.number }};TEST_NAME=test"

--- a/.github/workflows/openshift-tests.yaml
+++ b/.github/workflows/openshift-tests.yaml
@@ -1,0 +1,31 @@
+on:
+  issue_comment:
+    types:
+      - created
+jobs:
+  openshift-tests:
+    # This job only runs for '[test]' pull request comments by owner, member
+    name: "integration tests: RHEL-8 OpenShift 4"
+    runs-on: ubuntu-20.04
+
+    if: |
+      github.event.issue.pull_request
+      && contains(github.event.comment.body, '[test]')
+      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          ref: "refs/pull/${{ github.event.issue.number }}/head"
+
+      - name: Schedule tests for RHEL 8
+        uses: sclorg/testing-farm-as-github-action@v1
+        with:
+          api_key:  ${{ secrets.TF_INTERNAL_API_KEY }}
+          compose:  "RHEL-8.6.0-Nightly"
+          git_url:  "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
+          git_ref:  "main"
+          tf_scope: "private"
+          tmt_plan_regex: "rhel8-openshift-4"
+          pull_request_status_name: "RHEL8 - OpenShift 4"
+          variables: "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;REPO_NAME=$GITHUB_REPOSITORY;PR_NUMBER=${{ github.event.issue.number }}"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test-openshift-4
+
+test-openshift-4:
+	cd tests && PYTHONPATH=$(CURDIR) python3 -m pytest --color=yes --verbose --showlocals .

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test-openshift-4
+.PHONY: test
 
-test-openshift-4:
+test:
 	cd tests && PYTHONPATH=$(CURDIR) python3 -m pytest --color=yes --verbose --showlocals .


### PR DESCRIPTION
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

This pull request adds support for testing Helm Chart on our OpenShift 4 cluster together with container-ci-suite repository.