### PR TITLE
Add Apache HTTPD imagestreams for Helm-Charts

### DIFF
--- a/charts/redhat/httpd-imagestreams/OWNERS
+++ b/charts/redhat/httpd-imagestreams/OWNERS
@@ -1,0 +1,9 @@
+chart:
+  name: httpd-imagestreams
+  description: This is the Red Hat Postgresql Apache HTTP Server imagestream chart
+publicPgpKey: null
+users:
+  - githubUsername: phracek
+vendor:
+  label: redhat
+  name: Red Hat

--- a/charts/redhat/httpd-imagestreams/src/Chart.yaml
+++ b/charts/redhat/httpd-imagestreams/src/Chart.yaml
@@ -1,8 +1,8 @@
 description: |-
-  Red Hat Apache HTTP Server imagestreams.
+  This content is expermental, do not use it in production. Red Hat Apache HTTP Server imagestreams.
   For more information about HTTPD container see https://github.com/sclorg/httpd-container/.
 annotations:
-  charts.openshift.io/name: Red Hat Apache HTTP Server imagestreams.
+  charts.openshift.io/name: Red Hat Apache HTTP Server imagestreams (experimental).
 apiVersion: v2
 appVersion: 0.0.1
 kubeVersion: '>=1.20.0'

--- a/charts/redhat/httpd-imagestreams/src/Chart.yaml
+++ b/charts/redhat/httpd-imagestreams/src/Chart.yaml
@@ -1,0 +1,13 @@
+description: |-
+  Red Hat Apache HTTP Server imagestreams.
+  For more information about HTTPD container see https://github.com/sclorg/httpd-container/.
+annotations:
+  charts.openshift.io/name: Red Hat Apache HTTP Server imagestreams.
+apiVersion: v2
+appVersion: 0.0.1
+kubeVersion: '>=1.20.0'
+name: httpd-imagestreams
+tags: builder,httpd
+sources:
+  - https://github.com/sclorg/helm-charts
+version: 0.0.1

--- a/charts/redhat/httpd-imagestreams/src/templates/imagestreams.yaml
+++ b/charts/redhat/httpd-imagestreams/src/templates/imagestreams.yaml
@@ -1,0 +1,126 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    openshift.io/display-name: Apache HTTP Server (httpd)
+  name: httpd
+spec:
+  tags:
+    - annotations:
+        description: >-
+          Build and serve static content via Apache HTTP Server (httpd) on RHEL.
+          For more information about using this builder image, including
+          OpenShift considerations, see
+          https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.
+
+
+          WARNING: By selecting this tag, your application will automatically
+          update to use the latest version of Httpd available on OpenShift,
+          including major version updates.
+        iconClass: icon-apache
+        openshift.io/display-name: Apache HTTP Server (Latest)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/httpd-ex.git'
+        supports: httpd
+        tags: 'builder,httpd'
+      from:
+        kind: ImageStreamTag
+        name: 2.4-ubi8
+      referencePolicy:
+        type: Local
+      name: latest
+    - annotations:
+        description: >-
+          Build and serve static content via Apache HTTP Server (httpd) 2.4 on
+          UBI 9. For more information about using this builder image, including
+          OpenShift considerations, see
+          https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.
+        iconClass: icon-apache
+        openshift.io/display-name: Apache HTTP Server 2.4 (UBI 9)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/httpd-ex.git'
+        supports: httpd
+        tags: 'builder,httpd'
+        version: '2.4'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/ubi9/httpd-24:latest'
+      referencePolicy:
+        type: Local
+      name: 2.4-ubi9
+    - annotations:
+        description: >-
+          Build and serve static content via Apache HTTP Server (httpd) 2.4 on
+          RHEL 8. For more information about using this builder image, including
+          OpenShift considerations, see
+          https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.
+        iconClass: icon-apache
+        openshift.io/display-name: Apache HTTP Server 2.4 (UBI 8)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/httpd-ex.git'
+        supports: httpd
+        tags: 'builder,httpd'
+        version: '2.4'
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/ubi8/httpd-24:latest'
+      referencePolicy:
+        type: Local
+      name: 2.4-ubi8
+    - annotations:
+        description: >-
+          Build and serve static content via Apache HTTP Server (httpd) 2.4 on
+          RHEL 8. For more information about using this builder image, including
+          OpenShift considerations, see
+          https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.
+        iconClass: icon-apache
+        openshift.io/display-name: Apache HTTP Server 2.4 (RHEL 8)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/httpd-ex.git'
+        supports: httpd
+        tags: 'builder,httpd,hidden'
+        version: '2.4'
+      from:
+        kind: DockerImage
+        name: registry.redhat.io/rhel8/httpd-24
+      referencePolicy:
+        type: Local
+      name: 2.4-el8
+    - annotations:
+        description: >-
+          Build and serve static content via Apache HTTP Server (httpd) 2.4 on
+          RHEL 7. For more information about using this builder image, including
+          OpenShift considerations, see
+          https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.
+        iconClass: icon-apache
+        openshift.io/display-name: Apache HTTP Server 2.4 (RHEL 7)
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/httpd-ex.git'
+        supports: httpd
+        tags: 'builder,httpd'
+        version: '2.4'
+      from:
+        kind: DockerImage
+        name: registry.redhat.io/rhscl/httpd-24-rhel7
+      referencePolicy:
+        type: Local
+      name: 2.4-el7
+    - annotations:
+        description: >-
+          Build and serve static content via Apache HTTP Server (httpd) 2.4 on
+          RHEL 7. For more information about using this builder image, including
+          OpenShift considerations, see
+          https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.
+        iconClass: icon-apache
+        openshift.io/display-name: Apache HTTP Server 2.4
+        openshift.io/provider-display-name: 'Red Hat, Inc.'
+        sampleRepo: 'https://github.com/sclorg/httpd-ex.git'
+        supports: httpd
+        tags: 'builder,httpd,hidden'
+        version: '2.4'
+      from:
+        kind: DockerImage
+        name: registry.redhat.io/rhscl/httpd-24-rhel7
+      referencePolicy:
+        type: Local
+      name: '2.4'

--- a/charts/redhat/postgresql-persistent/OWNERS
+++ b/charts/redhat/postgresql-persistent/OWNERS
@@ -1,6 +1,6 @@
 chart:
   name: postgresql-persistent
-  description: This is the Red Hat Varnish Cache HTTP reverse proxy imagestream chart
+  description: This is the Red Hat PostgreSQL persistent storage chart
 publicPgpKey: null
 users:
   - githubUsername: phracek

--- a/charts/redhat/varnish-imagestreams/OWNERS
+++ b/charts/redhat/varnish-imagestreams/OWNERS
@@ -1,6 +1,6 @@
 chart:
-  name: postgresql-imagestreams
-  description: This is the Red Hat Postgresql imagestreams chart
+  name: varnish-imagestreams
+  description: This is the Red Hat Varnish imagestreams chart
 publicPgpKey: null
 users:
   - githubUsername: phracek

--- a/tests/test_httpd_imagestreams.py
+++ b/tests/test_httpd_imagestreams.py
@@ -1,0 +1,36 @@
+import os
+
+import pytest
+from pathlib import Path
+
+from container_ci_suite.helm import HelmChartsAPI
+
+test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
+
+
+class TestHelmHttpdImageStreams:
+
+    def setup_method(self):
+        package_name = "httpd-imagestreams"
+        path = test_dir / "../charts/redhat"
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
+
+    def teardown_method(self):
+        self.hc_api.delete_project()
+
+    @pytest.mark.parametrize(
+        "version,registry",
+        [
+            ("2.4-ubi9", "registry.redhat.io/ubi9/httpd-24:latest"),
+            ("2.4-ubi8", "registry.redhat.io/ubi8/httpd-24:latest"),
+            ("2.4-el8", "registry.redhat.io/rhel8/httpd-24:latest"),
+            ("2.4-el7", "registry.redhat.io/rhscl/httpd-24-rhel7:latest"),
+            ("2.4", "registry.redhat.io/rhscl/httpd-24-rhel7:latest"),
+            ("12-el7", "registry.redhat.io/rhscl/postgresql-12-rhel7:latest"),
+        ],
+    )
+    def test_package_imagestream(self, version, registry):
+        self.hc_api.set_version("0.0.1")
+        self.hc_api.helm_package()
+        self.hc_api.helm_installation()
+        assert self.hc_api.check_imagestreams(version=version, registry=registry)

--- a/tests/test_httpd_imagestreams.py
+++ b/tests/test_httpd_imagestreams.py
@@ -23,10 +23,9 @@ class TestHelmHttpdImageStreams:
         [
             ("2.4-ubi9", "registry.redhat.io/ubi9/httpd-24:latest"),
             ("2.4-ubi8", "registry.redhat.io/ubi8/httpd-24:latest"),
-            ("2.4-el8", "registry.redhat.io/rhel8/httpd-24:latest"),
-            ("2.4-el7", "registry.redhat.io/rhscl/httpd-24-rhel7:latest"),
-            ("2.4", "registry.redhat.io/rhscl/httpd-24-rhel7:latest"),
-            ("12-el7", "registry.redhat.io/rhscl/postgresql-12-rhel7:latest"),
+            ("2.4-el8", "registry.redhat.io/rhel8/httpd-24"),
+            ("2.4-el7", "registry.redhat.io/rhscl/httpd-24-rhel7"),
+            ("2.4", "registry.redhat.io/rhscl/httpd-24-rhel7"),
         ],
     )
     def test_package_imagestream(self, version, registry):


### PR DESCRIPTION
This pull request adds support for HTTPD imagestreams Helm Charts.
