### PR TITLE
Migrate httpd-template from DeploymentConfig to Deployment.

### DIFF
--- a/charts/redhat/httpd-template/src/Chart.yaml
+++ b/charts/redhat/httpd-template/src/Chart.yaml
@@ -4,10 +4,10 @@ description: This content is expermental, do not use it in production. An exampl
 name: httpd-template
 tags: quickstart,httpd
 kubeVersion: '>=1.20.0'
-version: 0.0.4
+version: 0.0.5
 annotations:
   charts.openshift.io/name: Red Hat Apache HTTP Server (httpd) application (experimental).
 apiVersion: v2
-appVersion: 0.0.4
+appVersion: 0.0.5
 sources:
   - https://github.com/sclorg/helm-charts

--- a/charts/redhat/httpd-template/src/templates/buildconfig.yaml
+++ b/charts/redhat/httpd-template/src/templates/buildconfig.yaml
@@ -8,11 +8,13 @@ metadata:
     app: httpd-example
     template: httpd-example
   name: {{ .Values.name }}
+  namespace: {{ .Release.Namespace }}
 spec:
   output:
     to:
       kind: ImageStreamTag
       name: {{ .Values.name }}:latest
+      namespace: {{ .Release.Namespace }}
   source:
     contextDir: {{ .Values.context_dir }}
     git:

--- a/charts/redhat/httpd-template/src/templates/deployment.yaml
+++ b/charts/redhat/httpd-template/src/templates/deployment.yaml
@@ -1,24 +1,36 @@
-apiVersion: apps.openshift.io/v1
-kind: DeploymentConfig
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   annotations:
     description: Defines how to deploy the application server
     template.alpha.openshift.io/wait-for-ready: "true"
+    image.openshift.io/triggers: |-
+      [
+        {
+          "from":{
+            "kind":"ImageStreamTag",
+            "name":"{{ .Values.name }}:example-latest"
+          },
+          "fieldPath":"spec.template.spec.containers[0].image"
+        }
+      ]
+  name: "{{ .Values.name }}"
   labels:
-    app: httpd-example
-    template: httpd-example
-  name: {{ .Values.name }}
+    app: "{{ .Values.name }}-example"
+    template: "{{ .Values.name }}-example"
+  namespace: "{{ .Release.Namespace }}"
 spec:
   replicas: 1
   selector:
-    name: {{ .Values.name }}
+    matchLabels:
+      app: "{{ .Values.name }}-example"
   strategy:
-    type: Rolling
+    type: RollingUpdate
   template:
     metadata:
       labels:
-        name: {{ .Values.name }}
-      name: {{ .Values.name }}
+        app: "{{ .Values.name }}-example"
+      namespace: "{{ .Release.Namespace }}"
     spec:
       containers:
       - env: []
@@ -29,7 +41,7 @@ spec:
             port: 8080
           initialDelaySeconds: 30
           timeoutSeconds: 3
-        name: httpd-example
+        name: "{{ .Values.name }}-example"
         ports:
         - containerPort: 8080
         readinessProbe:
@@ -41,14 +53,3 @@ spec:
         resources:
           limits:
             memory: {{ .Values.memory_limit }}
-  triggers:
-  - imageChangeParams:
-      automatic: true
-      containerNames:
-      - httpd-example
-      from:
-        kind: ImageStreamTag
-        name: "{{ .Values.name }}:latest"
-        namespace: {{ .Values.namespace }}
-    type: ImageChange
-  - type: ConfigChange


### PR DESCRIPTION
Migrate httpd-template from DeploymentConfig to Deployment.

Bump httpd-template version to 0.0.5

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
