### PR TITLE
Do not check test on shared cluster by curl command

### DIFF
--- a/tests/test_httpd_template.py
+++ b/tests/test_httpd_template.py
@@ -19,6 +19,8 @@ class TestHelmHTTPDTemplate:
         self.hc_api.delete_project()
 
     def test_package_persistent_by_curl(self):
+        if self.hc_api.oc_api.shared_cluster:
+            pytest.skip("Do NOT test on shared cluster")
         self.hc_api.package_name = "httpd-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()

--- a/tests/test_mysql_template.py
+++ b/tests/test_mysql_template.py
@@ -16,7 +16,6 @@ class TestHelmMySQLDBPersistent:
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
 
     def teardown_method(self):
-
         self.hc_api.delete_project()
 
     def test_package_persistent(self):

--- a/tests/test_nginx_template.py
+++ b/tests/test_nginx_template.py
@@ -19,6 +19,8 @@ class TestHelmNginxTemplate:
         self.hc_api.delete_project()
 
     def test_curl_connection(self):
+        if self.hc_api.oc_api.shared_cluster:
+            pytest.skip("Do NOT test on shared cluster")
         self.hc_api.package_name = "nginx-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()

--- a/tests/test_nodejs_application.py
+++ b/tests/test_nodejs_application.py
@@ -19,6 +19,8 @@ class TestHelmNodeJSApplication:
         self.hc_api.delete_project()
 
     def test_curl_connection(self):
+        if self.hc_api.oc_api.shared_cluster:
+            pytest.skip("Do NOT test on shared cluster")
         self.hc_api.package_name = "nodejs-imagestreams"
         self.hc_api.helm_package()
         assert self.hc_api.helm_installation()

--- a/tests/test_perl_dancer_app.py
+++ b/tests/test_perl_dancer_app.py
@@ -19,6 +19,8 @@ class TestHelmPerlDancerAppTemplate:
         self.hc_api.delete_project()
 
     def test_dancer_application_curl_output(self):
+        if self.hc_api.oc_api.shared_cluster:
+            pytest.skip("Do NOT test on shared cluster")
         self.hc_api.package_name = "perl-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()

--- a/tests/test_perl_dancer_mysql_template.py
+++ b/tests/test_perl_dancer_mysql_template.py
@@ -19,6 +19,8 @@ class TestHelmPerlDancerMysqlAppTemplate:
         self.hc_api.delete_project()
 
     def test_dancer_application(self):
+        if self.hc_api.oc_api.shared_cluster:
+            pytest.skip("Do NOT test on shared cluster")
         self.hc_api.package_name = "perl-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()

--- a/tests/test_php_cakephp_application.py
+++ b/tests/test_php_cakephp_application.py
@@ -19,6 +19,8 @@ class TestHelmCakePHPTemplate:
         self.hc_api.delete_project()
 
     def test_curl_connection(self):
+        if self.hc_api.oc_api.shared_cluster:
+            pytest.skip("Do NOT test on shared cluster")
         self.hc_api.package_name = "php-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()

--- a/tests/test_python_django_app.py
+++ b/tests/test_python_django_app.py
@@ -19,6 +19,8 @@ class TestHelmPythonDjangoAppTemplate:
         self.hc_api.delete_project()
 
     def test_django_application_curl_output(self):
+        if self.hc_api.oc_api.shared_cluster:
+            pytest.skip("Do NOT test on shared cluster")
         self.hc_api.package_name = "python-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()

--- a/tests/test_python_django_psql_persistent.py
+++ b/tests/test_python_django_psql_persistent.py
@@ -19,6 +19,8 @@ class TestHelmPythonDjangoPsqlTemplate:
         self.hc_api.delete_project()
 
     def test_django_psql_curl_output(self):
+        if self.hc_api.oc_api.shared_cluster:
+            pytest.skip("Do NOT test on shared cluster")
         self.hc_api.package_name = "postgresql-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()

--- a/tests/test_ruby_rails_application.py
+++ b/tests/test_ruby_rails_application.py
@@ -19,6 +19,8 @@ class TestHelmCakePHPTemplate:
         self.hc_api.delete_project()
 
     def test_curl_connection(self):
+        if self.hc_api.oc_api.shared_cluster:
+            pytest.skip("Do NOT test on shared cluster")
         self.hc_api.package_name = "ruby-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()


### PR DESCRIPTION
This pull request disables the CURL test on the shared cluster.

The route is not exposed worldwide.
