### PR TITLE
Remove duplicate/incorrect header for postgres readme

### DIFF
--- a/charts/redhat/postgresql-persistent/src/README.md
+++ b/charts/redhat/postgresql-persistent/src/README.md
@@ -1,7 +1,5 @@
 # PostgreSQL helm chart
 
-# MariaDB helm chart
-
 A Helm chart for building and deploying a [PostgreSQL](https://github/sclorg/postgresql-container) application on OpenShift.
 
 For more information about helm charts see the official [Helm Charts Documentation](https://helm.sh/).


### PR DESCRIPTION
This looks like it was copy and pasted from the MariaDB readme and someone forgot to remove the old header.