### PR TITLE
Adds support for python helm charts on shared cluster.

### DIFF
--- a/charts/redhat/django-psql-persistent/src/templates/buildconfig.yaml
+++ b/charts/redhat/django-psql-persistent/src/templates/buildconfig.yaml
@@ -9,10 +9,19 @@ metadata:
     template: django-psql
   name: {{ .Values.name }}
 spec:
+  {{ if .Values.registry.enabled }}
+  output:
+    to:
+      kind: DockerImage
+      name: "{{ .Values.registry.name }}/{{ .Values.registry.namespace }}/{{ .Values.name }}:latest"
+    pushSecret:
+      name: images-paas-push-config
+  {{ else }}
   output:
     to:
       kind: ImageStreamTag
       name: {{ .Values.name }}:latest
+  {{ end }}
   postCommit:
     script: ./manage.py test
   source:

--- a/charts/redhat/django-psql-persistent/src/templates/buildconfig.yaml
+++ b/charts/redhat/django-psql-persistent/src/templates/buildconfig.yaml
@@ -15,7 +15,7 @@ spec:
       kind: DockerImage
       name: "{{ .Values.registry.name }}/{{ .Values.registry.namespace }}/{{ .Values.name }}:latest"
     pushSecret:
-      name: images-paas-push-config
+      name: {{ .Values.registry.push_secret }}
   {{ else }}
   output:
     to:

--- a/charts/redhat/django-psql-persistent/src/templates/deployment.yaml
+++ b/charts/redhat/django-psql-persistent/src/templates/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Defines how to deploy the application server
+    {{ if not .Values.registry.enabled }}
     image.openshift.io/triggers: |-
       [
         {
@@ -13,6 +14,7 @@ metadata:
           "fieldPath": "spec.template.spec.containers[0].image"
         }
       ]
+    {{ end }}
     template.alpha.openshift.io/wait-for-ready: "true"
   labels:
     app: django-psql
@@ -56,7 +58,11 @@ spec:
             secretKeyRef:
               key: django-secret-key
               name: {{ .Values.name }}
-        image: ' '
+        {{ if .Values.registry.enabled }}
+        image: "{{ .Values.registry.name }}/{{ .Values.registry.namespace }}/{{ .Values.name }}:latest"
+        {{ else }}
+        image: " "
+        {{ end }}
         livenessProbe:
           httpGet:
             path: /health

--- a/charts/redhat/django-psql-persistent/src/templates/persistentvolumeclaim.yaml
+++ b/charts/redhat/django-psql-persistent/src/templates/persistentvolumeclaim.yaml
@@ -1,13 +1,24 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  {{ if .Values.pvc.netapp_nfs }}
+  annotations:
+    trident.netapp.io/reclaimPolicy: Delete
+  {{ end }}
   labels:
     app: django-psql
     template: django-psql
+    {{ if .Values.pvc.netapp_nfs }}
+    paas.redhat.com/appcode: {{ .Values.pvc.app_code }}
+    {{ end }}
   name: {{ .Values.database_service_name }}
 spec:
   accessModes:
   - ReadWriteOnce
   resources:
     requests:
-      storage: {{ .Values.volume_capacity }}
+      storage: {{ .Values.pvc.volume_capacity }}
+  {{ if .Values.pvc.netapp_nfs }}
+  storageClassName: netapp-nfs
+  volumeMode: Filesystem
+  {{ end }}

--- a/charts/redhat/django-psql-persistent/src/values.schema.json
+++ b/charts/redhat/django-psql-persistent/src/values.schema.json
@@ -90,6 +90,10 @@
                 "namespace": {
                     "type": "string",
                     "description": "The namespace of registry that will be used for pushing built image."
+                },
+                "push_secret": {
+                    "type": "string",
+                    "description": "The push secret to push image to registry."
                 }
             }
         },

--- a/charts/redhat/django-psql-persistent/src/values.schema.json
+++ b/charts/redhat/django-psql-persistent/src/values.schema.json
@@ -77,14 +77,41 @@
             "sliderMax": 65536,
             "sliderUnit": "Mi"
         },
-        "volume_capacity": {
-            "type": "string",
-            "title": "Persistent Volume Size",
-            "form": true,
-            "render": "slider",
-            "sliderMin": 1,
-            "sliderMax": 100,
-            "sliderUnit": "Gi"
+        "registry": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of registry that will be used for pushing built image."
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "The namespace of registry that will be used for pushing built image."
+                }
+            }
+        },
+        "pvc": {
+            "type": "object",
+            "properties": {
+                "volume_capacity": {
+                    "type": "string",
+                    "title": "Persistent Volume Size",
+                    "form": true,
+                    "render": "slider",
+                    "sliderMin": 1,
+                    "sliderMax": 100,
+                    "sliderUnit": "Gi"
+                },
+                "netapp_nfs": {
+                    "type": "boolean"
+                },
+                "app_code": {
+                    "type": "string"
+                }
+            }
         }
     }
 }

--- a/charts/redhat/django-psql-persistent/src/values.yaml
+++ b/charts/redhat/django-psql-persistent/src/values.yaml
@@ -13,8 +13,15 @@ memory_postgresql_limit: 512Mi
 name: django-psql
 namespace: openshift
 pip_index_url: "" # TODO: must define a default value for .pip_index_url
-postgresql_version: 12-el8
+postgresql_version: 15-el8
 python_version: 3.11-ubi8
 source_repository_ref: 2.2.x # TODO: must define a default value for .source_repository_ref
 source_repository_url: https://github.com/sclorg/django-ex.git
-volume_capacity: 1Gi
+registry:
+    enabled: false
+    name: "quay.io"
+    namespace: "something"
+pvc:
+  volume_capacity: 1Gi
+  app_code: "something"
+  netapp_nfs: false

--- a/charts/redhat/django-psql-persistent/src/values.yaml
+++ b/charts/redhat/django-psql-persistent/src/values.yaml
@@ -21,6 +21,7 @@ registry:
     enabled: false
     name: "quay.io"
     namespace: "something"
+    push_secret: ""
 pvc:
   volume_capacity: 1Gi
   app_code: "something"

--- a/charts/redhat/postgresql-persistent/src/templates/persistentvolumeclaim.yaml
+++ b/charts/redhat/postgresql-persistent/src/templates/persistentvolumeclaim.yaml
@@ -1,12 +1,23 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  {{ if .Values.pvc.netapp_nfs }}
+  annotations:
+    trident.netapp.io/reclaimPolicy: Delete
+  {{ end }}
   labels:
     template: postgresql-persistent-template
+    {{ if .Values.pvc.netapp_nfs }}
+    paas.redhat.com/appcode: {{ .Values.pvc.app_code }}
+    {{ end }}
   name: {{ .Values.database_service_name }}
 spec:
   accessModes:
   - ReadWriteOnce
   resources:
     requests:
-      storage: {{ .Values.volume_capacity }}
+      storage: {{ .Values.pvc.volume_capacity }}
+  {{ if .Values.pvc.netapp_nfs }}
+  storageClassName: netapp-nfs
+  volumeMode: Filesystem
+  {{ end }}

--- a/charts/redhat/postgresql-persistent/src/values.schema.json
+++ b/charts/redhat/postgresql-persistent/src/values.schema.json
@@ -26,15 +26,6 @@
                 }
             }
         },
-        "volume_capacity": {
-            "type": "string",
-            "title": "Persistent Volume Size",
-            "form": true,
-            "render": "slider",
-            "sliderMin": 1,
-            "sliderMax": 100,
-            "sliderUnit": "Gi"
-        },
         "memory_limit": {
             "type": "string",
             "title": "Database memory limit",
@@ -51,6 +42,26 @@
                     "type": "string",
                     "description": "Specify postgresql imagestream tag",
                     "enum": ["latest", "13-el9", "13-el8", "12-el8", "12" ]
+                }
+            }
+        },
+        "pvc": {
+            "type": "object",
+            "properties": {
+                "volume_capacity": {
+                    "type": "string",
+                    "title": "Persistent Volume Size",
+                    "form": true,
+                    "render": "slider",
+                    "sliderMin": 1,
+                    "sliderMax": 100,
+                    "sliderUnit": "Gi"
+                },
+                "netapp_nfs": {
+                    "type": "boolean"
+                },
+                "app_code": {
+                    "type": "string"
                 }
             }
         }

--- a/charts/redhat/postgresql-persistent/src/values.yaml
+++ b/charts/redhat/postgresql-persistent/src/values.yaml
@@ -1,7 +1,6 @@
 database_service_name: postgresql-persistent
 memory_limit: 512Mi
 namespace: postgresql-persistent-testing
-volume_capacity: 1Gi
 config:
   postgresql_database: testdb
   postgresql_password: testp
@@ -9,3 +8,7 @@ config:
   port: 5432
 image:
   tag: "13-el8"
+pvc:
+  volume_capacity: 1Gi
+  app_code: "something"
+  netapp_nfs: false

--- a/charts/redhat/python-django-application/src/templates/buildconfig.yaml
+++ b/charts/redhat/python-django-application/src/templates/buildconfig.yaml
@@ -15,7 +15,7 @@ spec:
       kind: DockerImage
       name: "{{ .Values.registry.name }}/{{ .Values.registry.namespace }}/{{ .Values.name }}:latest"
     pushSecret:
-      name: images-paas-push-config
+      name: {{ .Values.registry.push_secret }}
   {{ else }}
   output:
     to:

--- a/charts/redhat/python-django-application/src/templates/buildconfig.yaml
+++ b/charts/redhat/python-django-application/src/templates/buildconfig.yaml
@@ -9,12 +9,23 @@ metadata:
     template: django-example
   name: {{ .Values.name }}
 spec:
+  {{ if .Values.registry.enabled }}
+  output:
+    to:
+      kind: DockerImage
+      name: "{{ .Values.registry.name }}/{{ .Values.registry.namespace }}/{{ .Values.name }}:latest"
+    pushSecret:
+      name: images-paas-push-config
+  {{ else }}
   output:
     to:
       kind: ImageStreamTag
-      name: "{{ .Values.name }}:latest"
+      name: {{ .Values.name }}:latest
+  {{ end }}
+  {{ if not .Values.registry.enabled }}
   postCommit:
     script: ./manage.py test
+  {{ end }}
   source:
     contextDir: {{ .Values.context_dir }}
     git:

--- a/charts/redhat/python-django-application/src/templates/deployment.yaml
+++ b/charts/redhat/python-django-application/src/templates/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Defines how to deploy the application server
+    {{ if not .Values.registry.enabled }}
     image.openshift.io/triggers: |-
       [
         {
@@ -13,6 +14,7 @@ metadata:
           "fieldPath": "spec.template.spec.containers[0].image"
         }
       ]
+    {{ end }}
     template.alpha.openshift.io/wait-for-ready: "true"
   labels:
     app: django-example
@@ -40,7 +42,11 @@ spec:
             secretKeyRef:
               key: django-secret-key
               name: {{ .Values.name }}
-        image: ' '
+        {{ if .Values.registry.enabled }}
+        image: "{{ .Values.registry.name }}/{{ .Values.registry.namespace }}/{{ .Values.name }}:latest"
+        {{ else }}
+        image: " "
+        {{ end }}
         livenessProbe:
           httpGet:
             path: /

--- a/charts/redhat/python-django-application/src/values.schema.json
+++ b/charts/redhat/python-django-application/src/values.schema.json
@@ -68,6 +68,10 @@
                 "namespace": {
                     "type": "string",
                     "description": "The namespace of registry that will be used for pushing built image."
+                },
+                "push_secret": {
+                    "type": "string",
+                    "description": "The push secret to push image to registry."
                 }
             }
         }

--- a/charts/redhat/python-django-application/src/values.schema.json
+++ b/charts/redhat/python-django-application/src/values.schema.json
@@ -54,6 +54,22 @@
         "source_repository_ref": {
             "type": "string",
             "description": "Set this to a branch name, tag or other ref of your repository if you are not using the default branch."
+        },
+        "registry": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of registry that will be used for pushing built image."
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "The namespace of registry that will be used for pushing built image."
+                }
+            }
         }
     }
 }

--- a/charts/redhat/python-django-application/src/values.yaml
+++ b/charts/redhat/python-django-application/src/values.yaml
@@ -14,3 +14,4 @@ registry:
     enabled: false
     name: "quay.io"
     namespace: "something"
+    push_secret: ""

--- a/charts/redhat/python-django-application/src/values.yaml
+++ b/charts/redhat/python-django-application/src/values.yaml
@@ -10,4 +10,7 @@ python_version: 3.11-ubi8
 source_repository_ref: 2.2.x # TODO: must define a default value for .source_repository_ref
 source_repository_url: https://github.com/sclorg/django-ex.git
 app_config: "" # TODO: must define a default value for .app_config
-
+registry:
+    enabled: false
+    name: "quay.io"
+    namespace: "something"

--- a/tests/test_httpd_imagestreams.py
+++ b/tests/test_httpd_imagestreams.py
@@ -14,8 +14,6 @@ class TestHelmRHELHttpdImageStreams:
         package_name = "httpd-imagestreams"
         path = test_dir / "../charts/redhat"
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
-        assert self.hc_api.helm_package()
-        assert self.hc_api.helm_installation()
 
     def teardown_method(self):
         self.hc_api.delete_project()
@@ -30,4 +28,6 @@ class TestHelmRHELHttpdImageStreams:
         ],
     )
     def test_httpd_imagestream(self, version, registry, expected):
+        assert self.hc_api.helm_package()
+        assert self.hc_api.helm_installation()
         assert self.hc_api.check_imagestreams(version=version, registry=registry) == expected

--- a/tests/test_mariadb_imagestreams.py
+++ b/tests/test_mariadb_imagestreams.py
@@ -14,8 +14,6 @@ class TestHelmRHELMariadbImageStreams:
         package_name = "mariadb-imagestreams"
         path = test_dir / "../charts/redhat"
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
-        assert self.hc_api.helm_package()
-        assert self.hc_api.helm_installation()
 
     def teardown_method(self):
         self.hc_api.delete_project()
@@ -31,4 +29,6 @@ class TestHelmRHELMariadbImageStreams:
         ],
     )
     def test_package_imagestream(self, version, registry, expected):
+        assert self.hc_api.helm_package()
+        assert self.hc_api.helm_installation()
         assert self.hc_api.check_imagestreams(version=version, registry=registry) == expected

--- a/tests/test_mysql_imagestreams.py
+++ b/tests/test_mysql_imagestreams.py
@@ -14,8 +14,6 @@ class TestHelmRHELMySQLImageStreams:
         package_name = "mysql-imagestreams"
         path = test_dir / "../charts/redhat"
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
-        assert self.hc_api.helm_package()
-        assert self.hc_api.helm_installation()
 
     def teardown_method(self):
         self.hc_api.delete_project()
@@ -28,4 +26,6 @@ class TestHelmRHELMySQLImageStreams:
         ],
     )
     def test_package_imagestream(self, version, registry, expected):
+        assert self.hc_api.helm_package()
+        assert self.hc_api.helm_installation()
         assert self.hc_api.check_imagestreams(version=version, registry=registry) == expected

--- a/tests/test_nginx_imagestreams.py
+++ b/tests/test_nginx_imagestreams.py
@@ -14,8 +14,6 @@ class TestHelmRHELNginxImageStreams:
         package_name = "nginx-imagestreams"
         path = test_dir / "../charts/redhat"
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
-        assert self.hc_api.helm_package()
-        assert self.hc_api.helm_installation()
 
     def teardown_method(self):
         self.hc_api.delete_project()
@@ -32,31 +30,6 @@ class TestHelmRHELNginxImageStreams:
         ],
     )
     def test_package_imagestream(self, version, registry, expected):
-        assert self.hc_api.check_imagestreams(version=version, registry=registry) == expected
-
-
-class TestHelmCentOSNginxImageStreams:
-
-    def setup_method(self):
-        package_name = "nginx-imagestreams"
-        path = test_dir / "../charts/centos"
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-
-    def teardown_method(self):
-        self.hc_api.delete_project()
-
-    @pytest.mark.parametrize(
-        "version,registry,expected",
-        [
-            ("1.24-ubi9", "registry.access.redhat.com/ubi9/nginx-124:latest", True),
-            ("1.24-ubi8", "registry.access.redhat.com/ubi8/nginx-124:latest", True),
-            ("1.22-ubi9", "registry.access.redhat.com/ubi9/nginx-122:latest", True),
-            ("1.22-ubi8", "registry.access.redhat.com/ubi8/nginx-122:latest", True),
-            ("1.20-ubi9", "registry.access.redhat.com/ubi9/nginx-120:latest", True),
-            ("1.20-ubi8", "registry.access.redhat.com/ubi8/nginx-120:latest", False),
-        ],
-    )
-    def test_package_imagestream(self, version, registry, expected):
         assert self.hc_api.check_imagestreams(version=version, registry=registry) == expected

--- a/tests/test_nodejs_imagestreams.py
+++ b/tests/test_nodejs_imagestreams.py
@@ -35,32 +35,3 @@ class TestHelmRHELNodeJSImageStreams:
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
         assert self.hc_api.check_imagestreams(version=version, registry=registry)
-
-
-class TestHelmCentOSNodeJSImageStreams:
-
-    def setup_method(self):
-        package_name = "nodejs-imagestreams"
-        path = test_dir / "../charts/centos"
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
-
-    def teardown_method(self):
-        self.hc_api.delete_project()
-
-    @pytest.mark.parametrize(
-        "version,registry",
-        [
-            ("20-ubi9", "registry.access.redhat.com/ubi9/nodejs-20:latest"),
-            ("20-ubi9-minimal", "registry.access.redhat.com/ubi9/nodejs-20-minimal:latest"),
-            ("20-ubi8", "registry.access.redhat.com/ubi8/nodejs-20:latest"),
-            ("20-ubi8-minimal", "registry.access.redhat.com/ubi8/nodejs-20-minimal:latest"),
-            ("18-ubi9", "registry.access.redhat.com/ubi9/nodejs-18:latest"),
-            ("18-ubi9-minimal", "registry.access.redhat.com/ubi9/nodejs-18-minimal:latest"),
-            ("18-ubi8", "registry.access.redhat.com/ubi8/nodejs-18:latest"),
-            ("18-ubi8-minimal", "registry.access.redhat.com/ubi8/nodejs-18-minimal:latest"),
-        ],
-    )
-    def test_package_imagestream(self, version, registry):
-        assert self.hc_api.helm_package()
-        assert self.hc_api.helm_installation()
-        assert self.hc_api.check_imagestreams(version=version, registry=registry)

--- a/tests/test_perl_imagestreams.py
+++ b/tests/test_perl_imagestreams.py
@@ -14,8 +14,6 @@ class TestHelmRHELPerlImageStreams:
         package_name = "perl-imagestreams"
         path = test_dir / "../charts/redhat"
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
-        assert self.hc_api.helm_package()
-        assert self.hc_api.helm_installation()
 
     def teardown_method(self):
         self.hc_api.delete_project()
@@ -29,4 +27,6 @@ class TestHelmRHELPerlImageStreams:
         ],
     )
     def test_package_imagestream(self, version, registry):
+        assert self.hc_api.helm_package()
+        assert self.hc_api.helm_installation()
         assert self.hc_api.check_imagestreams(version=version, registry=registry)

--- a/tests/test_php_imagestreams.py
+++ b/tests/test_php_imagestreams.py
@@ -14,8 +14,6 @@ class TestHelmRHELPHPImageStreams:
         package_name = "php-imagestreams"
         path = test_dir / "../charts/redhat"
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
-        assert self.hc_api.helm_package()
-        assert self.hc_api.helm_installation()
 
     def teardown_method(self):
         self.hc_api.delete_project()
@@ -32,31 +30,6 @@ class TestHelmRHELPHPImageStreams:
         ],
     )
     def test_package_imagestream(self, version, registry, expected):
-        assert self.hc_api.check_imagestreams(version=version, registry=registry) == expected
-
-
-class TestHelmCentOSPHPImageStreams:
-
-    def setup_method(self):
-        package_name = "php-imagestreams"
-        path = test_dir / "../charts/centos"
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-
-    def teardown_method(self):
-        self.hc_api.delete_project()
-
-    @pytest.mark.parametrize(
-        "version,registry,expected",
-        [
-            ("8.2-ubi9", "registry.access.redhat.com/ubi9/php-82:latest", True),
-            ("8.2-ubi8", "registry.access.redhat.com/ubi8/php-82:latest", True),
-            ("8.1-ubi9", "registry.access.redhat.com/ubi9/php-81:latest", True),
-            ("8.0-ubi9", "registry.access.redhat.com/ubi9/php-80:latest", True),
-            ("8.0-ubi8", "registry.access.redhat.com/ubi8/php-80:latest", True),
-            ("7.4-ubi8", "registry.access.redhat.com/ubi8/php-74:latest", True),
-        ],
-    )
-    def test_package_imagestream(self, version, registry, expected):
         assert self.hc_api.check_imagestreams(version=version, registry=registry) == expected

--- a/tests/test_postgresql_imagestreams.py
+++ b/tests/test_postgresql_imagestreams.py
@@ -34,31 +34,3 @@ class TestHelmRHELPostgresqlImageStreams:
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
         assert self.hc_api.check_imagestreams(version=version, registry=registry) == expected
-
-
-class TestHelmCentOSLPostgresqlImageStreams:
-
-    def setup_method(self):
-        package_name = "postgresql-imagestreams"
-        path = test_dir / "../charts/centos"
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
-
-    def teardown_method(self):
-        self.hc_api.delete_project()
-
-    @pytest.mark.parametrize(
-        "version,registry,expected",
-        [
-            ("16-el9", "quay.io/sclorg/postgresql-16-c9s:latest", True),
-            ("16-el8", "quay.io/sclorg/postgresql-16-c8s:latest", False),
-            ("15-el9", "quay.io/sclorg/postgresql-15-c9s:latest", True),
-            ("15-el8", "quay.io/sclorg/postgresql-15-c8s:latest", False),
-            ("13-el9", "quay.io/sclorg/postgresql-13-c9s:latest", True),
-            ("13-el8", "quay.io/sclorg/postgresql-13-c8s:latest", False),
-            ("12-el8", "quay.io/sclorg/postgresql-12-c8s:latest", False),
-        ],
-    )
-    def test_package_imagestream(self, version, registry, expected):
-        assert self.hc_api.helm_package()
-        assert self.hc_api.helm_installation()
-        assert self.hc_api.check_imagestreams(version=version, registry=registry) == expected

--- a/tests/test_postgresql_template.py
+++ b/tests/test_postgresql_template.py
@@ -18,12 +18,23 @@ class TestHelmPostgresqlPersistent:
     def teardown_method(self):
         self.hc_api.delete_project()
 
-    def test_package_persistent(self):
+    @pytest.mark.parametrize(
+        "version",
+        [
+            "13-el8",
+            "13-el9",
+            "15-el8",
+            "15-el9",
+            "16-el8",
+            "16-el9",
+        ],
+    )
+    def test_package_persistent(self, version):
         self.hc_api.package_name = "postgresql-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
         self.hc_api.package_name = "postgresql-persistent"
         assert self.hc_api.helm_package()
-        assert self.hc_api.helm_installation(values={".image.tag": "13-el8", ".namespace": self.hc_api.namespace})
+        assert self.hc_api.helm_installation(values={".image.tag": version, ".namespace": self.hc_api.namespace})
         assert self.hc_api.is_pod_running(pod_name_prefix="postgresql-persistent")
         assert self.hc_api.test_helm_chart(expected_str=["accepting connection"])

--- a/tests/test_python_django_app.py
+++ b/tests/test_python_django_app.py
@@ -76,5 +76,5 @@ class TestHelmPythonDjangoAppTemplate:
                 "source_repository_ref": branch,
             }
         )
-        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="django-example")
+        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="django-example", timeout=300)
         assert self.hc_api.test_helm_chart(expected_str=["Welcome to your Django application"])

--- a/tests/test_python_django_psql_persistent.py
+++ b/tests/test_python_django_psql_persistent.py
@@ -67,6 +67,9 @@ class TestHelmPythonDjangoPsqlTemplate:
         ],
     )
     def test_django_psql_helm_test(self, version, branch):
+        # TODO: Solve problem with wrong permissions on data /var/psql/lib/data mount point.
+        if self.hc_api.oc_api.shared_cluster:
+            pytest.skip("Do NOT test on shared cluster")
         self.hc_api.package_name = "postgresql-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
@@ -80,7 +83,8 @@ class TestHelmPythonDjangoPsqlTemplate:
                 "python_version": version,
                 "namespace": self.hc_api.namespace,
                 "source_repository_ref": branch,
+                "postgresql_version": "15-el9"
             }
         )
-        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="django-psql")
+        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="django-psql", timeout=360)
         assert self.hc_api.test_helm_chart(expected_str=["Welcome to your Django application"])

--- a/tests/test_python_imagestreams.py
+++ b/tests/test_python_imagestreams.py
@@ -14,8 +14,6 @@ class TestHelmRHELPythonImageStreams:
         package_name = "python-imagestreams"
         path = test_dir / "../charts/redhat"
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
-        assert self.hc_api.helm_package()
-        assert self.hc_api.helm_installation()
 
     def teardown_method(self):
         self.hc_api.delete_project()
@@ -33,4 +31,6 @@ class TestHelmRHELPythonImageStreams:
         ],
     )
     def test_package_imagestream(self, version, registry):
+        assert self.hc_api.helm_package()
+        assert self.hc_api.helm_installation()
         assert self.hc_api.check_imagestreams(version=version, registry=registry)

--- a/tests/test_python_imagestreams.py
+++ b/tests/test_python_imagestreams.py
@@ -14,6 +14,8 @@ class TestHelmRHELPythonImageStreams:
         package_name = "python-imagestreams"
         path = test_dir / "../charts/redhat"
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
+        assert self.hc_api.helm_package()
+        assert self.hc_api.helm_installation()
 
     def teardown_method(self):
         self.hc_api.delete_project()
@@ -31,34 +33,4 @@ class TestHelmRHELPythonImageStreams:
         ],
     )
     def test_package_imagestream(self, version, registry):
-        assert self.hc_api.helm_package()
-        assert self.hc_api.helm_installation()
-        assert self.hc_api.check_imagestreams(version=version, registry=registry)
-
-
-class TestHelmCentOSPythonImageStreams:
-
-    def setup_method(self):
-        package_name = "python-imagestreams"
-        path = test_dir / "../charts/centos"
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
-
-    def teardown_method(self):
-        self.hc_api.delete_project()
-
-    @pytest.mark.parametrize(
-        "version,registry",
-        [
-            ("3.12-ubi9", "registry.access.redhat.com/ubi9/python-312:latest"),
-            ("3.12-ubi8", "registry.access.redhat.com/ubi8/python-312:latest"),
-            ("3.11-ubi9", "registry.access.redhat.com/ubi9/python-311:latest"),
-            ("3.11-ubi8", "registry.access.redhat.com/ubi8/python-311:latest"),
-            ("3.9-ubi9", "registry.access.redhat.com/ubi9/python-39:latest"),
-            ("3.9-ubi8", "registry.access.redhat.com/ubi8/python-39:latest"),
-            ("3.6-ubi8", "registry.access.redhat.com/ubi8/python-36:latest"),
-        ],
-    )
-    def test_package_imagestream(self, version, registry):
-        assert self.hc_api.helm_package()
-        assert self.hc_api.helm_installation()
         assert self.hc_api.check_imagestreams(version=version, registry=registry)

--- a/tests/test_redis_imagestreams.py
+++ b/tests/test_redis_imagestreams.py
@@ -14,8 +14,6 @@ class TestHelmRHELRedisImageStreams:
         package_name = "redis-imagestreams"
         path = test_dir / "../charts/redhat"
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
-        assert self.hc_api.helm_package()
-        assert self.hc_api.helm_installation()
 
     def teardown_method(self):
         self.hc_api.delete_project()
@@ -28,4 +26,6 @@ class TestHelmRHELRedisImageStreams:
         ],
     )
     def test_package_imagestream(self, version, registry, expected):
+        assert self.hc_api.helm_package()
+        assert self.hc_api.helm_installation()
         assert self.hc_api.check_imagestreams(version=version, registry=registry) == expected

--- a/tests/test_ruby_imagestreams.py
+++ b/tests/test_ruby_imagestreams.py
@@ -33,30 +33,3 @@ class TestHelmRHELRubyImageStreams:
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
         assert self.hc_api.check_imagestreams(version=version, registry=registry)
-
-
-class TestHelmCentOSRubyImageStreams:
-
-    def setup_method(self):
-        package_name = "ruby-imagestreams"
-        path = test_dir / "../charts/centos"
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
-
-    def teardown_method(self):
-        self.hc_api.delete_project()
-
-    @pytest.mark.parametrize(
-        "version,registry",
-        [
-            ("3.3-ubi9", "registry.access.redhat.com/ubi9/ruby-33:latest"),
-            ("3.1-ubi9", "registry.access.redhat.com/ubi9/ruby-31:latest"),
-            ("3.3-ubi8", "registry.access.redhat.com/ubi8/ruby-33:latest"),
-            ("3.1-ubi8", "registry.access.redhat.com/ubi8/ruby-31:latest"),
-            ("3.0-ubi9", "registry.access.redhat.com/ubi9/ruby-30:latest"),
-            ("2.5-ubi8", "registry.access.redhat.com/ubi8/ruby-25:latest"),
-        ],
-    )
-    def test_package_imagestream(self, version, registry):
-        assert self.hc_api.helm_package()
-        assert self.hc_api.helm_installation()
-        assert self.hc_api.check_imagestreams(version=version, registry=registry)

--- a/tests/test_valkey_imagestreams.py
+++ b/tests/test_valkey_imagestreams.py
@@ -7,6 +7,7 @@ from container_ci_suite.helm import HelmChartsAPI
 
 test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
 
+
 class TestHelmCentOSValkeyImageStreams:
 
     def setup_method(self):


### PR DESCRIPTION
We can not use internal OpenShift registry
and therefore Internal quay.io registry is used.
The values are defined in internal json file.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
