### PR TITLE
Enables testing NOdeJS Helm chart on shared cluster.

### DIFF
--- a/charts/redhat/nodejs-application/src/Chart.yaml
+++ b/charts/redhat/nodejs-application/src/Chart.yaml
@@ -2,13 +2,13 @@ description: This content is experimental, do not use it in production. An examp
   about using this template, including OpenShift considerations, see https://github.com/sclorg/nodejs-ex/blob/master/README.md.
 name: nodejs-application
 tags: quickstart,nodejs
-version: 0.0.1
+version: 0.0.2
 kubeVersion: '>=1.20.0'
 annotations:
   charts.openshift.io/name: Red Hat Apache Rails application with no database (experimental)
   charts.openshift.io/provider: Red Hat
   charts.openshift.io/providerType: redhat
 apiVersion: v2
-appVersion: 0.0.1
+appVersion: 0.0.2
 sources:
   - https://github.com/sclorg/helm-charts

--- a/charts/redhat/nodejs-application/src/templates/buildconfig.yaml
+++ b/charts/redhat/nodejs-application/src/templates/buildconfig.yaml
@@ -9,10 +9,19 @@ metadata:
     template: nodejs-example
   name: {{ .Values.name }}
 spec:
+  {{ if .Values.registry.enabled }}
+  output:
+    to:
+      kind: DockerImage
+      name: "{{ .Values.registry.name }}/{{ .Values.registry.namespace }}/{{ .Values.name }}:latest"
+    pushSecret:
+      name: {{ .Values.registry.push_secret }}
+  {{ else }}
   output:
     to:
       kind: ImageStreamTag
       name: {{ .Values.name }}:latest
+  {{ end }}
   source:
     contextDir: {{ .Values.context_dir }}
     git:

--- a/charts/redhat/nodejs-application/src/templates/deployment.yaml
+++ b/charts/redhat/nodejs-application/src/templates/deployment.yaml
@@ -34,10 +34,11 @@ spec:
       name: {{ .Values.name }}
     spec:
       containers:
+      - name: nodejs-example
         {{ if .Values.registry.enabled }}
-      - image: "{{ .Values.registry.name }}/{{ .Values.registry.namespace }}/{{ .Values.name }}:latest"
+        image: "{{ .Values.registry.name }}/{{ .Values.registry.namespace }}/{{ .Values.name }}:latest"
         {{ else }}
-      - image: " "
+        image: " "
         {{ end }}
         livenessProbe:
           httpGet:
@@ -45,7 +46,6 @@ spec:
             port: 8080
           initialDelaySeconds: 30
           timeoutSeconds: 3
-        name: nodejs-example
         ports:
         - containerPort: 8080
         readinessProbe:

--- a/charts/redhat/nodejs-application/src/templates/deployment.yaml
+++ b/charts/redhat/nodejs-application/src/templates/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Defines how to deploy the application server
+    {{ if not .Values.registry.enabled }}
     image.openshift.io/triggers: |-
       [
         {
@@ -13,6 +14,7 @@ metadata:
           "fieldPath": "spec.template.spec.containers[0].image"
         }
       ]
+    {{ end }}
     template.alpha.openshift.io/wait-for-ready: "true"
   labels:
     app: nodejs-example
@@ -32,7 +34,11 @@ spec:
       name: {{ .Values.name }}
     spec:
       containers:
+        {{ if .Values.registry.enabled }}
+      - image: "{{ .Values.registry.name }}/{{ .Values.registry.namespace }}/{{ .Values.name }}:latest"
+        {{ else }}
       - image: " "
+        {{ end }}
         livenessProbe:
           httpGet:
             path: /

--- a/charts/redhat/nodejs-application/src/values.schema.json
+++ b/charts/redhat/nodejs-application/src/values.schema.json
@@ -49,6 +49,26 @@
         "npm_mirror": {
             "type": "string",
             "description": "The custom NPM mirror URL."
+        },
+        "registry": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of registry that will be used for pushing built image."
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "The namespace of registry that will be used for pushing built image."
+                },
+                "push_secret": {
+                    "type": "string",
+                    "description": "The push secret to push image to registry."
+                }
+            }
         }
     }
 }

--- a/charts/redhat/nodejs-application/src/values.yaml
+++ b/charts/redhat/nodejs-application/src/values.yaml
@@ -9,3 +9,8 @@ nodejs_version: 20-ubi8
 npm_mirror: "" # TODO: must define a default value for .npm_mirror
 source_repository_ref: "master" # TODO: must define a default value for .source_repository_ref
 source_repository_url: https://github.com/sclorg/nodejs-ex.git
+registry:
+    enabled: false
+    name: "quay.io"
+    namespace: "something"
+    push_secret: ""

--- a/tests/test_nodejs_application.py
+++ b/tests/test_nodejs_application.py
@@ -39,7 +39,7 @@ class TestHelmNodeJSApplication:
         assert self.hc_api.helm_installation()
         self.hc_api.package_name = "nodejs-application"
         assert self.hc_api.helm_package()
-        pod_name = f"nodejs-ex-{version}"
+        pod_name = f"nodejs-ex-{version}".replace("-minimal", "")
         assert self.hc_api.helm_installation(
             values={
                 "nodejs_version": version,
@@ -72,7 +72,7 @@ class TestHelmNodeJSApplication:
         assert self.hc_api.helm_installation()
         self.hc_api.package_name = "nodejs-application"
         assert self.hc_api.helm_package()
-        pod_name = f"nodejs-ex-{version}"
+        pod_name = f"nodejs-ex-{version}".replace("-minimal", "")
         assert self.hc_api.helm_installation(
             values={
                 "nodejs": version,


### PR DESCRIPTION
Enables testing NOdeJS Helm chart on shared cluster.

The enablement has to be specified in values.yaml file
