### PR TITLE
Nodejs-20 reached EOL in April 2026.

### DIFF
--- a/charts/redhat/redhat-nodejs-application/src/values.schema.json
+++ b/charts/redhat/redhat-nodejs-application/src/values.schema.json
@@ -12,8 +12,8 @@
         },
         "nodejs_version": {
             "type": "string",
-            "description": "Version of NodeJS image to be used (20-ubi8, 22-ubi9, or latest).",
-            "enum": [ "latest", "20-ubi8", "20-ubi9", "22-ubi9", "22-ubi10", "24-ubi10", "24-ubi9" ]
+            "description": "Version of NodeJS image to be used (22-ubi9, or latest).",
+            "enum": [ "latest", "22-ubi9", "22-ubi10", "24-ubi10", "24-ubi9" ]
         },
         "memory_limit": {
             "type": "string",

--- a/charts/redhat/redhat-nodejs-imagestreams/src/templates/nodejs-imagestream.yaml
+++ b/charts/redhat/redhat-nodejs-imagestreams/src/templates/nodejs-imagestream.yaml
@@ -116,37 +116,6 @@ spec:
       name: registry.redhat.io/ubi9/nodejs-22:latest
     referencePolicy:
       type: Local
-  - name: 20-ubi9
-    annotations:
-      openshift.io/display-name: Node.js 20 (UBI 9)
-      openshift.io/provider-display-name: Red Hat, Inc.
-      description: Build and run Node.js 20 applications on UBI 9. For more information
-        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.
-      iconClass: icon-nodejs
-      tags: builder,nodejs
-      version: '20'
-      sampleRepo: https://github.com/sclorg/nodejs-ex.git
-    from:
-      kind: DockerImage
-      name: registry.redhat.io/ubi9/nodejs-20:latest
-    referencePolicy:
-      type: Local
-  - name: 20-ubi9-minimal
-    annotations:
-      openshift.io/display-name: Node.js 20 (UBI 9 Minimal)
-      openshift.io/provider-display-name: Red Hat, Inc.
-      description: Build and run Node.js 20 applications on UBI 9 Minimal. For more
-        information about using this builder image, including OpenShift considerations,
-        see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.
-      iconClass: icon-nodejs
-      tags: builder,nodejs
-      version: '20'
-      sampleRepo: https://github.com/sclorg/nodejs-ex.git
-    from:
-      kind: DockerImage
-      name: registry.redhat.io/ubi9/nodejs-20-minimal:latest
-    referencePolicy:
-      type: Local
   - name: 22-ubi10-minimal
     annotations:
       openshift.io/display-name: Node.js 22 (UBI 10 Minimal)
@@ -208,36 +177,5 @@ spec:
     from:
       kind: DockerImage
       name: registry.redhat.io/ubi8/nodejs-22-minimal:latest
-    referencePolicy:
-      type: Local
-  - name: 20-ubi8
-    annotations:
-      openshift.io/display-name: Node.js 20 (UBI 8)
-      openshift.io/provider-display-name: Red Hat, Inc.
-      description: Build and run Node.js 20 applications on UBI 8. For more information
-        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.
-      iconClass: icon-nodejs
-      tags: builder,nodejs
-      version: '20'
-      sampleRepo: https://github.com/sclorg/nodejs-ex.git
-    from:
-      kind: DockerImage
-      name: registry.redhat.io/ubi8/nodejs-20:latest
-    referencePolicy:
-      type: Local
-  - name: 20-ubi8-minimal
-    annotations:
-      openshift.io/display-name: Node.js 20 (UBI 8 Minimal)
-      openshift.io/provider-display-name: Red Hat, Inc.
-      description: Build and run Node.js 20 applications on UBI 8 Minimal. For more
-        information about using this builder image, including OpenShift considerations,
-        see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.
-      iconClass: icon-nodejs
-      tags: builder,nodejs
-      version: '20'
-      sampleRepo: https://github.com/sclorg/nodejs-ex.git
-    from:
-      kind: DockerImage
-      name: registry.redhat.io/ubi8/nodejs-20-minimal:latest
     referencePolicy:
       type: Local

--- a/tests/test_nodejs_application.py
+++ b/tests/test_nodejs_application.py
@@ -29,12 +29,8 @@ class TestHelmNodeJSApplication:
             "22-ubi10-minimal",
             "22-ubi9",
             "22-ubi9-minimal",
-            "20-ubi9",
-            "20-ubi9-minimal"
             "22-ubi8",
             "22-ubi8-minimal",
-            "20-ubi8",
-            "20-ubi8-minimal",
         ],
     )
     def test_by_helm_test(self, version):

--- a/tests/test_nodejs_imagestreams.py
+++ b/tests/test_nodejs_imagestreams.py
@@ -29,16 +29,8 @@ class TestHelmRHELNodeJSImageStreams:
             ("22-ubi10-minimal", "registry.redhat.io/ubi10/nodejs-22-minimal:latest", True),
             ("22-ubi9", "registry.redhat.io/ubi9/nodejs-22:latest", True),
             ("22-ubi9-minimal", "registry.redhat.io/ubi9/nodejs-22-minimal:latest", True),
-            ("20-ubi9", "registry.redhat.io/ubi9/nodejs-20:latest", True),
-            ("20-ubi9-minimal", "registry.redhat.io/ubi9/nodejs-20-minimal:latest", True),
             ("22-ubi8", "registry.redhat.io/ubi8/nodejs-22:latest", True),
             ("22-ubi8-minimal", "registry.redhat.io/ubi8/nodejs-22-minimal:latest", True),
-            ("20-ubi8", "registry.redhat.io/ubi8/nodejs-20:latest", True),
-            ("20-ubi8-minimal", "registry.redhat.io/ubi8/nodejs-20-minimal:latest", True),
-            ("18-ubi9", "registry.redhat.io/ubi9/nodejs-18:latest", False),
-            ("18-ubi9-minimal", "registry.redhat.io/ubi9/nodejs-18-minimal:latest", False),
-            ("18-ubi8", "registry.redhat.io/ubi8/nodejs-18:latest", False),
-            ("18-ubi8-minimal", "registry.redhat.io/ubi8/nodejs-18-minimal:latest", False),
         ],
     )
     def test_package_imagestream(self, helm_api, version, registry, expected):


### PR DESCRIPTION
Deprecation of Helm Charts for nodejs20.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Node.js 22 and 24 support (UBI 10 and UBI 9 variants, including minimal images).

* **Removed**
  * Removed Node.js 20 UBI variant support from selectable options.

* **Tests**
  * Updated test expectations and parametrizations to reflect the new/removed Node.js UBI variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sclorg/helm-charts/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->