### PR TITLE
Add support for testing PHP84 in Helm charts

### DIFF
--- a/charts/redhat/redhat-cakephp-application-template/src/values.schema.json
+++ b/charts/redhat/redhat-cakephp-application-template/src/values.schema.json
@@ -13,7 +13,7 @@
         "php_version": {
             "type": "string",
             "description": "Version of PHP image to be used (8.1-ubi9 by default).",
-            "enum": [ "latest", "7.4-ubi8", "8.0-ubi8", "8.2-ubi8", "8.0-ubi9", "8.2-ubi9", "8.3-ubi9", "8.3-ubi10" ]
+            "enum": [ "latest", "7.4-ubi8", "8.0-ubi8", "8.2-ubi8", "8.0-ubi9", "8.2-ubi9", "8.3-ubi9", "8.3-ubi10", "8.4-ubi10" ]
         },
         "memory_limit": {
             "type": "string",

--- a/charts/redhat/redhat-php-imagestreams/src/templates/php-imagestream.yaml
+++ b/charts/redhat/redhat-php-imagestreams/src/templates/php-imagestream.yaml
@@ -24,6 +24,22 @@ spec:
       name: 8.3-ubi9
     referencePolicy:
       type: Local
+  - name: 8.4-ubi10
+    annotations:
+      openshift.io/display-name: PHP 8.4 (UBI 10)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run PHP 8.4 applications on UBI 10. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.4/README.md.
+      iconClass: icon-php
+      tags: builder,php
+      supports: php:8.4,php
+      version: '8.4'
+      sampleRepo: https://github.com/sclorg/cakephp-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi10/php-84:latest
+    referencePolicy:
+      type: Local
   - name: 8.3-ubi10
     annotations:
       openshift.io/display-name: PHP 8.3 (UBI 10)

--- a/tests/test_php_cakephp_application.py
+++ b/tests/test_php_cakephp_application.py
@@ -26,6 +26,7 @@ class TestHelmCakePHPTemplate:
             "8.2-ubi9",
             "8.3-ubi9",
             "8.3-ubi10",
+            "8.4-ubi10",
         ]
     )
     def test_by_helm_test(self, version):

--- a/tests/test_php_cakephp_application.py
+++ b/tests/test_php_cakephp_application.py
@@ -30,17 +30,17 @@ class TestHelmCakePHPTemplate:
         ]
     )
     def test_by_helm_test(self, version):
-        branch_to_test = "4.X"
+        branch_to_test = "5.X"
         check_msg = "Welcome to CakePHP"
-        if version.startswith("8.2") or version.startswith("8.3"):
-            branch_to_test = "5.X"
+        if version.startswith("8.0"):
+            branch_to_test = "4.X"
             check_msg = "Welcome to CakePHP"
         self.hc_api.package_name = "redhat-php-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
         self.hc_api.package_name = "redhat-cakephp-application-template"
         assert self.hc_api.helm_package()
-        pod_name = f"cakephp-ex-{version}".replace(".", "-")
+        pod_name = f"cakephp-ex-{version}".replace(".", "")
         assert self.hc_api.helm_installation(
             values={
                 "php_version": version,

--- a/tests/test_php_imagestreams.py
+++ b/tests/test_php_imagestreams.py
@@ -20,19 +20,18 @@ class TestHelmRHELPHPImageStreams:
 
 
     @pytest.mark.parametrize(
-        "version,registry,expected",
+        "version,registry",
         [
-            ("8.3-ubi10", "registry.redhat.io/ubi10/php-83:latest", True),
-            ("8.3-ubi9", "registry.redhat.io/ubi9/php-83:latest", True),
-            ("8.2-ubi9", "registry.redhat.io/ubi9/php-82:latest", True),
-            ("8.2-ubi8", "registry.redhat.io/ubi8/php-82:latest", True),
-            ("8.1-ubi9", "registry.redhat.io/ubi9/php-81:latest", False),
-            ("8.0-ubi9", "registry.redhat.io/ubi9/php-80:latest", True),
-            ("8.0-ubi8", "registry.redhat.io/ubi8/php-80:latest", False),
-            ("7.4-ubi8", "registry.redhat.io/ubi8/php-74:latest", True),
+            ("8.4-ubi10", "registry.redhat.io/ubi10/php-84:latest"),
+            ("8.3-ubi10", "registry.redhat.io/ubi10/php-83:latest"),
+            ("8.3-ubi9", "registry.redhat.io/ubi9/php-83:latest"),
+            ("8.2-ubi9", "registry.redhat.io/ubi9/php-82:latest"),
+            ("8.2-ubi8", "registry.redhat.io/ubi8/php-82:latest"),
+            ("8.0-ubi9", "registry.redhat.io/ubi9/php-80:latest"),
+            ("7.4-ubi8", "registry.redhat.io/ubi8/php-74:latest"),
         ],
     )
-    def test_package_imagestream(self, helm_api,  version, registry, expected):
+    def test_package_imagestream(self, helm_api,  version, registry):
         assert helm_api.helm_package()
         assert helm_api.helm_installation()
-        assert helm_api.check_imagestreams(version=version, registry=registry) == expected
+        assert helm_api.check_imagestreams(version=version, registry=registry) == True


### PR DESCRIPTION
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for PHP 8.3 and 8.4 using UBI10 base images.

* **Image Updates**
  * Added an image stream entry so PHP 8.4 (UBI10) images are available.

* **Tests**
  * Test suite extended to cover PHP 8.4-ubi10 and updated to reflect the new version handling and validation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sclorg/helm-charts/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->