### PR TITLE
Add EOL Python-311 image

### DIFF
--- a/charts/redhat/redhat-python-django-application/src/values.schema.json
+++ b/charts/redhat/redhat-python-django-application/src/values.schema.json
@@ -21,7 +21,19 @@
         "python_version": {
             "type": "string",
             "description": "Specify Python imagestream tag",
-            "enum": [ "latest", "3.6-ubi8", "3.9-ubi8", "3.11-ubi8", "3.12-ubi8", "3.9-ubi9", "3.11-ubi9", "3.12-ubi9", "3.12-minimal-ubi9", "3.12-minimal-ubi10" ]
+            "enum": [
+                "latest",
+                "3.6-ubi8",
+                "3.9-ubi8",
+                "3.12-ubi8",
+                "3.9-ubi9",
+                "3.12-ubi9",
+                "3.12-minimal-ubi9",
+                "3.12-minimal-ubi10",
+                "3.14-ubi9",
+                "3.14-minimal-ubi9",
+                "3.14-minimal-ubi10"
+            ]
         },
         "application_domain": {
             "type": "string",
@@ -44,8 +56,8 @@
             "description": "Relative path to Gunicorn configuration file (optional)."
         },
         "django_secret_key": {
-          "type": "string",
-          "description": "Set this to a long random string."
+            "type": "string",
+            "description": "Set this to a long random string."
         },
         "source_repository_url": {
             "type": "string",
@@ -77,4 +89,3 @@
         }
     }
 }
-

--- a/charts/redhat/redhat-python-imagestreams/src/templates/python-imagestream.yaml
+++ b/charts/redhat/redhat-python-imagestreams/src/templates/python-imagestream.yaml
@@ -24,6 +24,22 @@ spec:
       name: 3.12-ubi9
     referencePolicy:
       type: Local
+  - name: 3.14-minimal-ubi10
+    annotations:
+      openshift.io/display-name: Python 3.14 (UBI 10)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.14 applications on UBI 10. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.14-minimal/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:3.14,python
+      version: '3.14-minimal'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi10/python-314-minimal:latest
+    referencePolicy:
+      type: Local
   - name: 3.12-minimal-ubi10
     annotations:
       openshift.io/display-name: Python 3.12 (UBI 10)
@@ -38,6 +54,38 @@ spec:
     from:
       kind: DockerImage
       name: registry.redhat.io/ubi10/python-312-minimal:latest
+    referencePolicy:
+      type: Local
+  - name: 3.14-minimal-ubi9
+    annotations:
+      openshift.io/display-name: Python 3.14 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.14 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.14-minimal/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:3.14,python
+      version: '3.14-minimal'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/python-314-minimal:latest
+    referencePolicy:
+      type: Local
+  - name: 3.14-ubi9
+    annotations:
+      openshift.io/display-name: Python 3.14 (UBI 9)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      description: Build and run Python 3.14 applications on UBI 9. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.14/README.md.
+      iconClass: icon-python
+      tags: builder,python
+      supports: python:3.14,python
+      version: '3.14'
+      sampleRepo: https://github.com/sclorg/django-ex.git
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/ubi9/python-314:latest
     referencePolicy:
       type: Local
   - name: 3.12-minimal-ubi9

--- a/tests/test_python_django_app.py
+++ b/tests/test_python_django_app.py
@@ -25,11 +25,11 @@ class TestHelmPythonDjangoAppTemplate:
     @pytest.mark.parametrize(
         "version,branch",
         [
+            ("3.14-minimal-ubi10", "4.2.x"),
+            ("3.14-ubi9", "4.2.x"),
             ("3.12-minimal-ubi10", "4.2.x"),
             ("3.12-ubi9", "4.2.x"),
             ("3.12-ubi8", "4.2.x"),
-            ("3.11-ubi9", "4.2.x"),
-            ("3.11-ubi8", "4.2.x"),
         ],
     )
     def test_django_application_helm_test(self, version, branch):
@@ -48,6 +48,4 @@ class TestHelmPythonDjangoAppTemplate:
             }
         )
         assert self.hc_api.is_s2i_pod_running(pod_name_prefix=pod_name, timeout=600)
-        assert self.hc_api.test_helm_chart(
-            expected_str=["Welcome to your Django application"]
-        )
+        assert self.hc_api.test_helm_chart(expected_str=["Welcome to your Django application"])

--- a/tests/test_python_django_psql_persistent.py
+++ b/tests/test_python_django_psql_persistent.py
@@ -25,11 +25,12 @@ class TestHelmPythonDjangoPsqlTemplate:
     @pytest.mark.parametrize(
         "version,pod_version,branch",
         [
+            ("3.14-minimal-ubi10", "3.14", "4.2.x"),
+            ("3.14-minimal-ubi9", "3.14", "4.2.x"),
             ("3.12-minimal-ubi10", "3.12", "4.2.x"),
+            ("3.14-ubi9", "3.14", "4.2.x"),
             ("3.12-ubi9", "3.12", "4.2.x"),
             ("3.12-ubi8", "3.12", "4.2.x"),
-            ("3.11-ubi9", "3.11", "4.2.x"),
-            ("3.11-ubi8", "3.11", "4.2.x"),
         ],
     )
     def test_django_psql_helm_test(self, version, pod_version, branch):
@@ -52,6 +53,4 @@ class TestHelmPythonDjangoPsqlTemplate:
             }
         )
         assert self.hc_api.is_s2i_pod_running(pod_name_prefix=pod_name, timeout=600)
-        assert self.hc_api.test_helm_chart(
-            expected_str=["Welcome to your Django application"]
-        )
+        assert self.hc_api.test_helm_chart(expected_str=["Welcome to your Django application"])

--- a/tests/test_python_imagestreams.py
+++ b/tests/test_python_imagestreams.py
@@ -7,9 +7,14 @@ from container_ci_suite.helm import HelmChartsAPI
 
 test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
 
+
 @pytest.fixture(scope="module")
 def helm_api(request):
-    helm_api = HelmChartsAPI(path=test_dir / "../charts/redhat", package_name="redhat-python-imagestreams", tarball_dir=test_dir)
+    helm_api = HelmChartsAPI(
+        path=test_dir / "../charts/redhat",
+        package_name="redhat-python-imagestreams",
+        tarball_dir=test_dir,
+    )
     # app_name = os.path.basename(request.param)
     yield helm_api
     pass
@@ -17,23 +22,21 @@ def helm_api(request):
 
 
 class TestHelmRHELPythonImageStreams:
-
-
     @pytest.mark.parametrize(
-        "version,registry,expected",
+        "version,registry",
         [
-            ("3.12-minimal-ubi10", "registry.redhat.io/ubi10/python-312-minimal:latest", True),
-            ("3.12-minimal-ubi9", "registry.redhat.io/ubi9/python-312-minimal:latest", True),
-            ("3.12-ubi9", "registry.redhat.io/ubi9/python-312:latest", True),
-            ("3.12-ubi8", "registry.redhat.io/ubi8/python-312:latest", True),
-            ("3.11-ubi9", "registry.redhat.io/ubi9/python-311:latest", True),
-            ("3.11-ubi8", "registry.redhat.io/ubi8/python-311:latest", True),
-            ("3.9-ubi9", "registry.redhat.io/ubi9/python-39:latest", True),
-            ("3.9-ubi8", "registry.redhat.io/ubi8/python-39:latest", False),
-            ("3.6-ubi8", "registry.redhat.io/ubi8/python-36:latest", True),
+            ("3.14-minimal-ubi10", "registry.redhat.io/ubi10/python-314-minimal:latest"),
+            ("3.12-minimal-ubi10", "registry.redhat.io/ubi10/python-312-minimal:latest"),
+            ("3.14-minimal-ubi9", "registry.redhat.io/ubi9/python-314-minimal:latest"),
+            ("3.12-minimal-ubi9", "registry.redhat.io/ubi9/python-312-minimal:latest"),
+            ("3.14-ubi9", "registry.redhat.io/ubi9/python-314:latest"),
+            ("3.12-ubi9", "registry.redhat.io/ubi9/python-312:latest"),
+            ("3.12-ubi8", "registry.redhat.io/ubi8/python-312:latest"),
+            ("3.9-ubi9", "registry.redhat.io/ubi9/python-39:latest"),
+            ("3.6-ubi8", "registry.redhat.io/ubi8/python-36:latest"),
         ],
     )
-    def test_package_imagestream(self, helm_api, version, registry, expected):
+    def test_package_imagestream(self, helm_api, version, registry):
         assert helm_api.helm_package()
         assert helm_api.helm_installation()
-        assert helm_api.check_imagestreams(version=version, registry=registry) == expected
+        assert helm_api.check_imagestreams(version=version, registry=registry)

--- a/tests/test_python_pr_unit.py
+++ b/tests/test_python_pr_unit.py
@@ -1,0 +1,433 @@
+"""
+Unit tests for PR changes:
+- charts/redhat/redhat-python-django-application/src/values.schema.json
+- charts/redhat/redhat-python-imagestreams/src/templates/python-imagestream.yaml
+- tests/test_python_django_app.py parametrize list
+- tests/test_python_django_psql_persistent.py parametrize list
+- tests/test_python_imagestreams.py parametrize list
+"""
+import json
+import os
+
+import pytest
+import yaml
+from pathlib import Path
+
+repo_root = Path(os.path.abspath(os.path.dirname(__file__))) / ".."
+SCHEMA_PATH = repo_root / "charts/redhat/redhat-python-django-application/src/values.schema.json"
+IMAGESTREAM_PATH = repo_root / "charts/redhat/redhat-python-imagestreams/src/templates/python-imagestream.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def load_schema():
+    with open(SCHEMA_PATH) as f:
+        return json.load(f)
+
+
+def load_imagestream():
+    with open(IMAGESTREAM_PATH) as f:
+        return yaml.safe_load(f)
+
+
+def imagestream_tags_by_name(imagestream):
+    """Return a dict mapping tag name -> tag dict."""
+    return {tag["name"]: tag for tag in imagestream["spec"]["tags"]}
+
+
+# ---------------------------------------------------------------------------
+# values.schema.json – python_version enum
+# ---------------------------------------------------------------------------
+
+class TestSchemaJsonValidity:
+    def test_schema_is_valid_json(self):
+        """The schema file must be parseable as JSON without errors."""
+        schema = load_schema()
+        assert isinstance(schema, dict)
+
+    def test_schema_has_required_top_level_keys(self):
+        schema = load_schema()
+        assert "$schema" in schema
+        assert "type" in schema
+        assert "properties" in schema
+
+    def test_python_version_enum_exists(self):
+        schema = load_schema()
+        assert "python_version" in schema["properties"]
+        assert "enum" in schema["properties"]["python_version"]
+
+    # --- new versions added in this PR ---
+
+    def test_python_version_enum_contains_3_14_ubi9(self):
+        enum = load_schema()["properties"]["python_version"]["enum"]
+        assert "3.14-ubi9" in enum
+
+    def test_python_version_enum_contains_3_14_minimal_ubi9(self):
+        enum = load_schema()["properties"]["python_version"]["enum"]
+        assert "3.14-minimal-ubi9" in enum
+
+    def test_python_version_enum_contains_3_14_minimal_ubi10(self):
+        enum = load_schema()["properties"]["python_version"]["enum"]
+        assert "3.14-minimal-ubi10" in enum
+
+    # --- versions removed in this PR ---
+
+    def test_python_version_enum_does_not_contain_3_11_ubi8(self):
+        enum = load_schema()["properties"]["python_version"]["enum"]
+        assert "3.11-ubi8" not in enum
+
+    def test_python_version_enum_does_not_contain_3_11_ubi9(self):
+        enum = load_schema()["properties"]["python_version"]["enum"]
+        assert "3.11-ubi9" not in enum
+
+    # --- versions that must remain ---
+
+    @pytest.mark.parametrize("version", [
+        "latest",
+        "3.6-ubi8",
+        "3.9-ubi8",
+        "3.12-ubi8",
+        "3.9-ubi9",
+        "3.12-ubi9",
+        "3.12-minimal-ubi9",
+        "3.12-minimal-ubi10",
+    ])
+    def test_python_version_enum_retains_existing_versions(self, version):
+        enum = load_schema()["properties"]["python_version"]["enum"]
+        assert version in enum
+
+    def test_python_version_enum_total_count(self):
+        """Enum should have exactly 11 entries after the PR changes."""
+        enum = load_schema()["properties"]["python_version"]["enum"]
+        assert len(enum) == 11
+
+    def test_python_version_enum_no_duplicates(self):
+        enum = load_schema()["properties"]["python_version"]["enum"]
+        assert len(enum) == len(set(enum))
+
+    # --- django_secret_key indentation fix (cosmetic, but field must still be valid) ---
+
+    def test_django_secret_key_field_present(self):
+        schema = load_schema()
+        assert "django_secret_key" in schema["properties"]
+
+    def test_django_secret_key_type_is_string(self):
+        field = load_schema()["properties"]["django_secret_key"]
+        assert field["type"] == "string"
+
+    def test_django_secret_key_has_description(self):
+        field = load_schema()["properties"]["django_secret_key"]
+        assert "description" in field
+        assert field["description"] == "Set this to a long random string."
+
+    # --- boundary / negative cases ---
+
+    def test_python_version_enum_does_not_contain_empty_string(self):
+        enum = load_schema()["properties"]["python_version"]["enum"]
+        assert "" not in enum
+
+    def test_python_version_enum_does_not_contain_none(self):
+        enum = load_schema()["properties"]["python_version"]["enum"]
+        assert None not in enum
+
+    def test_python_version_type_is_string(self):
+        field = load_schema()["properties"]["python_version"]
+        assert field["type"] == "string"
+
+
+# ---------------------------------------------------------------------------
+# python-imagestream.yaml – new 3.14 image stream entries
+# ---------------------------------------------------------------------------
+
+class TestImagestreamYamlValidity:
+    def test_imagestream_is_valid_yaml(self):
+        data = load_imagestream()
+        assert data is not None
+
+    def test_imagestream_kind(self):
+        data = load_imagestream()
+        assert data["kind"] == "ImageStream"
+
+    def test_imagestream_has_spec_tags(self):
+        data = load_imagestream()
+        assert "spec" in data
+        assert "tags" in data["spec"]
+        assert isinstance(data["spec"]["tags"], list)
+
+    # --- 3.14-minimal-ubi10 tag (new in this PR) ---
+
+    def test_tag_3_14_minimal_ubi10_exists(self):
+        tags = imagestream_tags_by_name(load_imagestream())
+        assert "3.14-minimal-ubi10" in tags
+
+    def test_tag_3_14_minimal_ubi10_docker_image(self):
+        tags = imagestream_tags_by_name(load_imagestream())
+        tag = tags["3.14-minimal-ubi10"]
+        assert tag["from"]["kind"] == "DockerImage"
+        assert tag["from"]["name"] == "registry.redhat.io/ubi10/python-314-minimal:latest"
+
+    def test_tag_3_14_minimal_ubi10_reference_policy(self):
+        tags = imagestream_tags_by_name(load_imagestream())
+        tag = tags["3.14-minimal-ubi10"]
+        assert tag["referencePolicy"]["type"] == "Local"
+
+    def test_tag_3_14_minimal_ubi10_annotations(self):
+        tags = imagestream_tags_by_name(load_imagestream())
+        ann = tags["3.14-minimal-ubi10"]["annotations"]
+        assert ann["iconClass"] == "icon-python"
+        assert "builder,python" in ann["tags"]
+        assert "python:3.14" in ann["supports"]
+        assert ann["version"] == "3.14-minimal"
+
+    def test_tag_3_14_minimal_ubi10_display_name(self):
+        tags = imagestream_tags_by_name(load_imagestream())
+        ann = tags["3.14-minimal-ubi10"]["annotations"]
+        assert "3.14" in ann["openshift.io/display-name"]
+        assert "UBI 10" in ann["openshift.io/display-name"]
+
+    def test_tag_3_14_minimal_ubi10_provider_display_name(self):
+        tags = imagestream_tags_by_name(load_imagestream())
+        ann = tags["3.14-minimal-ubi10"]["annotations"]
+        assert ann["openshift.io/provider-display-name"] == "Red Hat, Inc."
+
+    def test_tag_3_14_minimal_ubi10_sample_repo(self):
+        tags = imagestream_tags_by_name(load_imagestream())
+        ann = tags["3.14-minimal-ubi10"]["annotations"]
+        assert ann["sampleRepo"] == "https://github.com/sclorg/django-ex.git"
+
+    # --- 3.14-minimal-ubi9 tag (new in this PR) ---
+
+    def test_tag_3_14_minimal_ubi9_exists(self):
+        tags = imagestream_tags_by_name(load_imagestream())
+        assert "3.14-minimal-ubi9" in tags
+
+    def test_tag_3_14_minimal_ubi9_docker_image(self):
+        tags = imagestream_tags_by_name(load_imagestream())
+        tag = tags["3.14-minimal-ubi9"]
+        assert tag["from"]["kind"] == "DockerImage"
+        assert tag["from"]["name"] == "registry.redhat.io/ubi9/python-314-minimal:latest"
+
+    def test_tag_3_14_minimal_ubi9_reference_policy(self):
+        tags = imagestream_tags_by_name(load_imagestream())
+        tag = tags["3.14-minimal-ubi9"]
+        assert tag["referencePolicy"]["type"] == "Local"
+
+    def test_tag_3_14_minimal_ubi9_annotations(self):
+        tags = imagestream_tags_by_name(load_imagestream())
+        ann = tags["3.14-minimal-ubi9"]["annotations"]
+        assert ann["iconClass"] == "icon-python"
+        assert "builder,python" in ann["tags"]
+        assert "python:3.14" in ann["supports"]
+        assert ann["version"] == "3.14-minimal"
+
+    def test_tag_3_14_minimal_ubi9_display_name(self):
+        tags = imagestream_tags_by_name(load_imagestream())
+        ann = tags["3.14-minimal-ubi9"]["annotations"]
+        assert "3.14" in ann["openshift.io/display-name"]
+        assert "UBI 9" in ann["openshift.io/display-name"]
+
+    # --- 3.14-ubi9 tag (new in this PR) ---
+
+    def test_tag_3_14_ubi9_exists(self):
+        tags = imagestream_tags_by_name(load_imagestream())
+        assert "3.14-ubi9" in tags
+
+    def test_tag_3_14_ubi9_docker_image(self):
+        tags = imagestream_tags_by_name(load_imagestream())
+        tag = tags["3.14-ubi9"]
+        assert tag["from"]["kind"] == "DockerImage"
+        assert tag["from"]["name"] == "registry.redhat.io/ubi9/python-314:latest"
+
+    def test_tag_3_14_ubi9_reference_policy(self):
+        tags = imagestream_tags_by_name(load_imagestream())
+        tag = tags["3.14-ubi9"]
+        assert tag["referencePolicy"]["type"] == "Local"
+
+    def test_tag_3_14_ubi9_annotations(self):
+        tags = imagestream_tags_by_name(load_imagestream())
+        ann = tags["3.14-ubi9"]["annotations"]
+        assert ann["iconClass"] == "icon-python"
+        assert "builder,python" in ann["tags"]
+        assert "python:3.14" in ann["supports"]
+        assert ann["version"] == "3.14"
+
+    def test_tag_3_14_ubi9_display_name(self):
+        tags = imagestream_tags_by_name(load_imagestream())
+        ann = tags["3.14-ubi9"]["annotations"]
+        assert "3.14" in ann["openshift.io/display-name"]
+        assert "UBI 9" in ann["openshift.io/display-name"]
+
+    def test_tag_3_14_ubi9_sample_repo(self):
+        tags = imagestream_tags_by_name(load_imagestream())
+        ann = tags["3.14-ubi9"]["annotations"]
+        assert ann["sampleRepo"] == "https://github.com/sclorg/django-ex.git"
+
+    # --- ubi9 vs ubi10 registry path distinction ---
+
+    def test_3_14_minimal_ubi10_uses_ubi10_registry(self):
+        tags = imagestream_tags_by_name(load_imagestream())
+        name = tags["3.14-minimal-ubi10"]["from"]["name"]
+        assert "ubi10" in name
+        assert "ubi9" not in name
+
+    def test_3_14_minimal_ubi9_uses_ubi9_registry(self):
+        tags = imagestream_tags_by_name(load_imagestream())
+        name = tags["3.14-minimal-ubi9"]["from"]["name"]
+        assert "ubi9" in name
+        assert "ubi10" not in name
+
+    def test_3_14_ubi9_uses_ubi9_registry(self):
+        tags = imagestream_tags_by_name(load_imagestream())
+        name = tags["3.14-ubi9"]["from"]["name"]
+        assert "ubi9" in name
+        assert "ubi10" not in name
+
+    # --- all 3.14 tags use python-314 image name segment ---
+
+    @pytest.mark.parametrize("tag_name", [
+        "3.14-minimal-ubi10",
+        "3.14-minimal-ubi9",
+        "3.14-ubi9",
+    ])
+    def test_3_14_tags_use_python314_image(self, tag_name):
+        tags = imagestream_tags_by_name(load_imagestream())
+        image_name = tags[tag_name]["from"]["name"]
+        assert "python-314" in image_name
+
+    # --- no duplicated tag names ---
+
+    def test_imagestream_tag_names_are_unique(self):
+        data = load_imagestream()
+        names = [tag["name"] for tag in data["spec"]["tags"]]
+        assert len(names) == len(set(names))
+
+
+# ---------------------------------------------------------------------------
+# Consistency: schema enum <-> imagestream tags <-> test parametrize lists
+# ---------------------------------------------------------------------------
+
+# Versions in test_python_imagestreams.py parametrize (as changed by this PR)
+IMAGESTREAM_TEST_VERSIONS = [
+    ("3.14-minimal-ubi10", "registry.redhat.io/ubi10/python-314-minimal:latest"),
+    ("3.12-minimal-ubi10", "registry.redhat.io/ubi10/python-312-minimal:latest"),
+    ("3.14-minimal-ubi9",  "registry.redhat.io/ubi9/python-314-minimal:latest"),
+    ("3.12-minimal-ubi9",  "registry.redhat.io/ubi9/python-312-minimal:latest"),
+    ("3.14-ubi9",          "registry.redhat.io/ubi9/python-314:latest"),
+    ("3.12-ubi9",          "registry.redhat.io/ubi9/python-312:latest"),
+    ("3.12-ubi8",          "registry.redhat.io/ubi8/python-312:latest"),
+    ("3.9-ubi9",           "registry.redhat.io/ubi9/python-39:latest"),
+    ("3.6-ubi8",           "registry.redhat.io/ubi8/python-36:latest"),
+]
+
+# Versions in test_python_django_app.py parametrize (as changed by this PR)
+DJANGO_APP_TEST_VERSIONS = [
+    ("3.14-minimal-ubi10", "4.2.x"),
+    ("3.14-ubi9",          "4.2.x"),
+    ("3.12-minimal-ubi10", "4.2.x"),
+    ("3.12-ubi9",          "4.2.x"),
+    ("3.12-ubi8",          "4.2.x"),
+]
+
+# Versions in test_python_django_psql_persistent.py parametrize (as changed by this PR)
+DJANGO_PSQL_TEST_VERSIONS = [
+    ("3.14-minimal-ubi10", "3.14", "4.2.x"),
+    ("3.14-minimal-ubi9",  "3.14", "4.2.x"),
+    ("3.12-minimal-ubi10", "3.12", "4.2.x"),
+    ("3.14-ubi9",          "3.14", "4.2.x"),
+    ("3.12-ubi9",          "3.12", "4.2.x"),
+    ("3.12-ubi8",          "3.12", "4.2.x"),
+]
+
+
+class TestParametrizeConsistency:
+    """Verify the parametrize lists in test files are consistent with source files."""
+
+    def test_imagestream_test_versions_exist_in_yaml(self):
+        """Every version listed in test_python_imagestreams.py must exist in the YAML."""
+        tags = imagestream_tags_by_name(load_imagestream())
+        for version, _registry in IMAGESTREAM_TEST_VERSIONS:
+            assert version in tags, f"Version {version!r} missing from imagestream YAML"
+
+    def test_imagestream_test_registry_matches_yaml(self):
+        """Each registry URL in test_python_imagestreams.py must match the YAML DockerImage."""
+        tags = imagestream_tags_by_name(load_imagestream())
+        for version, registry in IMAGESTREAM_TEST_VERSIONS:
+            yaml_registry = tags[version]["from"]["name"]
+            assert yaml_registry == registry, (
+                f"Registry mismatch for {version!r}: "
+                f"test={registry!r}, yaml={yaml_registry!r}"
+            )
+
+    def test_django_app_versions_exist_in_schema_enum(self):
+        """Every python_version in test_python_django_app.py must be a valid schema enum value."""
+        enum = load_schema()["properties"]["python_version"]["enum"]
+        for version, _branch in DJANGO_APP_TEST_VERSIONS:
+            assert version in enum, f"Version {version!r} not in schema enum"
+
+    def test_django_psql_versions_exist_in_schema_enum(self):
+        """Every python_version in test_python_django_psql_persistent.py must be in the schema."""
+        enum = load_schema()["properties"]["python_version"]["enum"]
+        for version, _pod_version, _branch in DJANGO_PSQL_TEST_VERSIONS:
+            assert version in enum, f"Version {version!r} not in schema enum"
+
+    def test_3_11_removed_from_django_app_parametrize(self):
+        """3.11 versions must not be in the django app test list (removed in this PR)."""
+        for version, _branch in DJANGO_APP_TEST_VERSIONS:
+            assert not version.startswith("3.11"), (
+                f"Version {version!r} is 3.11 but should have been removed"
+            )
+
+    def test_3_11_removed_from_django_psql_parametrize(self):
+        """3.11 versions must not be in the django psql test list (removed in this PR)."""
+        for version, _pod_version, _branch in DJANGO_PSQL_TEST_VERSIONS:
+            assert not version.startswith("3.11"), (
+                f"Version {version!r} is 3.11 but should have been removed"
+            )
+
+    def test_3_14_present_in_django_app_parametrize(self):
+        """3.14 versions must appear in the django app test list (added in this PR)."""
+        versions_with_3_14 = [v for v, _ in DJANGO_APP_TEST_VERSIONS if v.startswith("3.14")]
+        assert len(versions_with_3_14) > 0, "No 3.14 versions found in DJANGO_APP_TEST_VERSIONS"
+
+    def test_3_14_present_in_django_psql_parametrize(self):
+        """3.14 versions must appear in the django psql test list (added in this PR)."""
+        versions_with_3_14 = [v for v, _, _ in DJANGO_PSQL_TEST_VERSIONS if v.startswith("3.14")]
+        assert len(versions_with_3_14) > 0, "No 3.14 versions found in DJANGO_PSQL_TEST_VERSIONS"
+
+    def test_imagestream_test_includes_new_3_14_versions(self):
+        """All three new 3.14 entries from the PR must be in the imagestream test list."""
+        test_versions = {v for v, _ in IMAGESTREAM_TEST_VERSIONS}
+        assert "3.14-minimal-ubi10" in test_versions
+        assert "3.14-minimal-ubi9" in test_versions
+        assert "3.14-ubi9" in test_versions
+
+    def test_3_11_not_in_imagestream_test_versions(self):
+        """3.11 versions were removed from test_python_imagestreams.py in this PR."""
+        for version, _registry in IMAGESTREAM_TEST_VERSIONS:
+            assert not version.startswith("3.11"), (
+                f"Version {version!r} is 3.11 but should have been removed"
+            )
+
+    def test_django_psql_pod_version_matches_python_version(self):
+        """The pod_version should be the major.minor extracted from the python_version."""
+        for version, pod_version, _branch in DJANGO_PSQL_TEST_VERSIONS:
+            # e.g. "3.14-minimal-ubi10" -> pod_version should be "3.14"
+            major_minor = version.split("-")[0]
+            assert major_minor == pod_version, (
+                f"For version {version!r}, pod_version {pod_version!r} "
+                f"does not match expected {major_minor!r}"
+            )
+
+    def test_imagestream_test_versions_no_duplicates(self):
+        versions = [v for v, _ in IMAGESTREAM_TEST_VERSIONS]
+        assert len(versions) == len(set(versions))
+
+    def test_django_app_test_versions_no_duplicates(self):
+        versions = [v for v, _ in DJANGO_APP_TEST_VERSIONS]
+        assert len(versions) == len(set(versions))
+
+    def test_django_psql_test_versions_no_duplicates(self):
+        versions = [v for v, _, _ in DJANGO_PSQL_TEST_VERSIONS]
+        assert len(versions) == len(set(versions))


### PR DESCRIPTION
Add missing 3.14 and 3.14-minimal python images

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Python 3.14 support with UBI9 and UBI10 minimal and standard image variants.

* **Chores**
  * Updated configuration schema to reflect the new Python version set and removed Python 3.11 entries.

* **Tests**
  * Expanded and added unit/validation tests to cover schema integrity, imagestream tags, and parametrization consistency for the new variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->