### PR TITLE
Update mysql-imagestreams and mysql-persistent Red Hat charts

### DIFF
--- a/charts/redhat/redhat-mysql-imagestreams/src/Chart.yaml
+++ b/charts/redhat/redhat-mysql-imagestreams/src/Chart.yaml
@@ -5,10 +5,10 @@ description: |-
 annotations:
   charts.openshift.io/name: Red Hat MySQL database service imagestreams (experimental)
 apiVersion: v2
-appVersion: 0.0.3
+appVersion: 0.0.4
 kubeVersion: '>=1.20.0'
 name: redhat-mysql-imagestreams
 tags: database,mysql
 sources:
   - https://github.com/sclorg/helm-charts
-version: 0.0.3
+version: 0.0.4

--- a/charts/redhat/redhat-mysql-imagestreams/src/templates/imagestreams.yaml
+++ b/charts/redhat/redhat-mysql-imagestreams/src/templates/imagestreams.yaml
@@ -58,35 +58,19 @@ spec:
         name: 'registry.redhat.io/rhel9/mysql-84:latest'
       referencePolicy:
         type: Local
-    - name: 8.0-el9
+    - name: 8.4-el8
       annotations:
-        openshift.io/display-name: MySQL 8.0 (RHEL 9)
+        openshift.io/display-name: MySQL 8.4 (RHEL 8)
         openshift.io/provider-display-name: 'Red Hat, Inc.'
         description: >-
-          Provides a MySQL 8.0 database on RHEL 9. For more information about
+          Provides a MySQL 8.4 database on RHEL 8. For more information about
           using this database image, including OpenShift considerations, see
           https://github.com/sclorg/mysql-container/blob/master/README.md.
         iconClass: icon-mysql-database
         tags: mysql
-        version: '8.0'
+        version: '8.4'
       from:
         kind: DockerImage
-        name: 'registry.redhat.io/rhel9/mysql-80:latest'
-      referencePolicy:
-        type: Local
-    - name: 8.0-el8
-      annotations:
-        openshift.io/display-name: MySQL 8.0 (RHEL 8)
-        openshift.io/provider-display-name: 'Red Hat, Inc.'
-        description: >-
-          Provides a MySQL 8.0 database on RHEL 8. For more information about
-          using this database image, including OpenShift considerations, see
-          https://github.com/sclorg/mysql-container/blob/master/README.md.
-        iconClass: icon-mysql-database
-        tags: mysql
-        version: '8.0'
-      from:
-        kind: DockerImage
-        name: 'registry.redhat.io/rhel8/mysql-80:latest'
+        name: 'registry.redhat.io/rhel8/mysql-84:latest'
       referencePolicy:
         type: Local

--- a/charts/redhat/redhat-mysql-persistent/src/Chart.yaml
+++ b/charts/redhat/redhat-mysql-persistent/src/Chart.yaml
@@ -4,11 +4,11 @@ description: |-
   NOTE: Scaling to more than one replica is not supported. You must have persistent volumes available in your cluster to use this template.
 name: redhat-mysql-persistent
 tags: database,mysql
-version: 0.0.5
+version: 0.0.6
 annotations:
   charts.openshift.io/name: Red Hat MySQL database service, with persistent storage (experimental)
 apiVersion: v2
-appVersion: 0.0.5
+appVersion: 0.0.6
 kubeVersion: '>=1.20.0'
 sources:
   - https://github.com/sclorg/helm-charts

--- a/charts/redhat/redhat-mysql-persistent/src/templates/tests/test-mysql-connection.yaml
+++ b/charts/redhat/redhat-mysql-persistent/src/templates/tests/test-mysql-connection.yaml
@@ -11,7 +11,7 @@ spec:
   #serviceAccount: {{ .Values.serviceAccount }}
   containers:
     - name: "mysql-connection-test"
-      image: "registry.redhat.io/rhel8/mysql-80:latest"
+      image: "registry.redhat.io/rhel9/mysql-84:latest"
       imagePullPolicy: IfNotPresent
       env:
         - name: MARIADB_USER

--- a/charts/redhat/redhat-mysql-persistent/src/values.schema.json
+++ b/charts/redhat/redhat-mysql-persistent/src/values.schema.json
@@ -42,7 +42,7 @@
         "mysql_version": {
             "type": "string",
             "description": "Specify mysql imagestream tag",
-            "enum": [ "latest", "8.0-el9", "8.4-el9", "8.0-el8", "8.4-el10"]
+            "enum": [ "latest", "8.4-el8", "8.4-el9", "8.4-el10"]
         },
         "pvc": {
             "type": "object",

--- a/charts/redhat/redhat-mysql-persistent/src/values.yaml
+++ b/charts/redhat/redhat-mysql-persistent/src/values.yaml
@@ -4,7 +4,7 @@ mysql_database: testdb
 mysql_password: testp # TODO: must define a default value for .mysql_password'
 mysql_root_password: testur # TODO: must define a default value for .mysql_root_password'
 mysql_user: testu # TODO: must define a default value for .mysql_user'
-mysql_version: 8.0-el8
+mysql_version: 8.4-el10
 namespace: openshift
 pvc:
   volume_capacity: 1Gi

--- a/charts/redhat/redhat-redis-imagestreams/src/Chart.yaml
+++ b/charts/redhat/redhat-redis-imagestreams/src/Chart.yaml
@@ -3,11 +3,13 @@ description: |-
   For more information about Redis container see https://github.com/sclorg/redis-container/.
 annotations:
   charts.openshift.io/name: Provides a Redis database on RHEL imagestreams (experimental)
+  charts.openshift.io/provider: Red Hat
+  charts.openshift.io/providerType: redhat
 apiVersion: v2
-appVersion: 0.0.4
+appVersion: 0.0.2
 kubeVersion: '>=1.20.0'
 name: redhat-redis-imagestreams
 tags: builder,redis
 sources:
   - https://github.com/sclorg/helm-charts
-version: 0.0.4
+version: 0.0.2

--- a/charts/redhat/redhat-redis-imagestreams/src/templates/imagestreams.yaml
+++ b/charts/redhat/redhat-redis-imagestreams/src/templates/imagestreams.yaml
@@ -10,7 +10,7 @@ spec:
         description: >-
           Provides a Redis database on RHEL. For more information about using
           this database image, including OpenShift considerations, see
-          https://github.com/sclorg/redis-container/tree/master/6/README.md.
+          https://github.com/sclorg/redis-container/tree/master/7/README.md.
 
 
           WARNING: By selecting this tag, your application will automatically
@@ -22,7 +22,7 @@ spec:
         tags: redis
       from:
         kind: ImageStreamTag
-        name: 6-el8
+        name: 7-el9
       referencePolicy:
         type: Local
       name: latest

--- a/charts/redhat/redhat-redis-persistent/src/Chart.yaml
+++ b/charts/redhat/redhat-redis-persistent/src/Chart.yaml
@@ -1,14 +1,16 @@
 description: |-
-  This content is experimental, do not use it in production. Redis in-memory data structure store, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/redis-container/blob/master/5.
+  This content is experimental, do not use it in production. Redis in-memory data structure store, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/redis-container/blob/master/7.
 
   NOTE: You must have persistent volumes available in your cluster to use this template.
 name: redhat-redis-persistent
 tags: database,redis
-version: 0.0.5
+version: 0.0.3
 annotations:
   charts.openshift.io/name: Red Hat Redis in-memory data structure store, with persistent storage (experimental)
+  charts.openshift.io/provider: Red Hat
+  charts.openshift.io/providerType: redhat
 apiVersion: v2
-appVersion: 0.0.5
+appVersion: 0.0.3
 kubeVersion: '>=1.20.0'
 sources:
   - https://github.com/sclorg/helm-charts

--- a/charts/redhat/redhat-redis-persistent/src/values.schema.json
+++ b/charts/redhat/redhat-redis-persistent/src/values.schema.json
@@ -24,7 +24,12 @@
         "redis_version": {
             "type": "string",
             "description": "Specify redis imagestream tag",
-            "enum": [ "latest", "7-el9", "6-el9", "6-el8" ]
+            "enum": [
+                "latest",
+                "7-el9",
+                "6-el9",
+                "6-el8"
+            ]
         },
         "pvc": {
             "type": "object",
@@ -48,4 +53,3 @@
         }
     }
 }
-

--- a/charts/redhat/redhat-redis-persistent/src/values.yaml
+++ b/charts/redhat/redhat-redis-persistent/src/values.yaml
@@ -2,7 +2,7 @@ database_service_name: redis
 memory_limit: 512Mi
 namespace: redis-persistent-testing
 redis_password: testp # TODO: must define a default value for .redis_password'
-redis_version: 6-el8
+redis_version: 7-el9
 pvc:
   volume_capacity: 1Gi
   app_code: "something"

--- a/charts/redhat/redhat-ruby-imagestreams/src/Chart.yaml
+++ b/charts/redhat/redhat-ruby-imagestreams/src/Chart.yaml
@@ -1,7 +1,7 @@
 description: |-
-  This content is expermental, do not use it in production. Ruby imagestreams on UBI.
+  This content is experimental, do not use it in production. Ruby imagestreams on UBI.
   For more information about using this builder image, including OpenShift considerations,
-  see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.
+  see https://github.com/sclorg/s2i-ruby-container/blob/master/4.0/README.md.
 annotations:
   charts.openshift.io/name: Red Hat Ruby applications on UBI (experimental)
 apiVersion: v2

--- a/charts/redhat/redhat-ruby-imagestreams/src/templates/ruby-imagestream.yaml
+++ b/charts/redhat/redhat-ruby-imagestreams/src/templates/ruby-imagestream.yaml
@@ -12,7 +12,7 @@ spec:
       openshift.io/display-name: Ruby (Latest)
       openshift.io/provider-display-name: Red Hat, Inc.
       description: |-
-        Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/3.3/README.md.
+        Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/4.0/README.md.
 
         WARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.
       iconClass: icon-ruby

--- a/charts/redhat/redhat-ruby-rails-application/src/Chart.yaml
+++ b/charts/redhat/redhat-ruby-rails-application/src/Chart.yaml
@@ -2,13 +2,13 @@ description: This content is experimental, do not use it in production. An examp
   using this template, including OpenShift considerations, see https://github.com/sclorg/rails-ex/blob/master/README.md.
 name: redhat-ruby-rails-application
 tags: quickstart,ruby,rails
-version: 0.0.6
+version: 0.0.2
 kubeVersion: '>=1.20.0'
 annotations:
   charts.openshift.io/name: Red Hat Apache Rails application with no database (experimental)
   charts.openshift.io/provider: Red Hat
   charts.openshift.io/providerType: redhat
 apiVersion: v2
-appVersion: 0.0.6
+appVersion: 0.0.2
 sources:
   - https://github.com/sclorg/helm-charts

--- a/charts/redhat/redhat-ruby-rails-application/src/values.schema.json
+++ b/charts/redhat/redhat-ruby-rails-application/src/values.schema.json
@@ -13,7 +13,16 @@
         "ruby_version": {
             "type": "string",
             "description": "Version of Ruby image to be used (3.0-ubi8 by default).",
-            "enum": [ "latest", "2.5-ubi8", "3.3-ubi8", "3.0-ubi9", "3.3-ubi9", "3.3-ubi10", "4.0-ubi9", "4.0-ubi10"]
+            "enum": [
+                "latest",
+                "2.5-ubi8",
+                "3.3-ubi8",
+                "3.0-ubi9",
+                "3.3-ubi9",
+                "3.3-ubi10",
+                "4.0-ubi9",
+                "4.0-ubi10"
+            ]
         },
         "memory_limit": {
             "type": "string",

--- a/charts/redhat/redhat-ruby-rails-application/src/values.yaml
+++ b/charts/redhat/redhat-ruby-rails-application/src/values.yaml
@@ -5,7 +5,7 @@ memory_limit: 512Mi
 name: rails-example
 namespace: openshift
 rails_env: production
-ruby_version: 3.3-ubi9
+ruby_version: 4.0-ubi10
 rubygem_mirror: "" # TODO: must define a default value for .rubygem_mirror
 secret_key_base: "" # TODO: must define a default value for .secret_key_base
 source_repository_ref: "master" # TODO: must define a default value for .source_repository_ref

--- a/charts/redhat/redhat-valkey-imagestreams/src/Chart.yaml
+++ b/charts/redhat/redhat-valkey-imagestreams/src/Chart.yaml
@@ -3,6 +3,8 @@ description: |-
   For more information about Valkey container see https://github.com/sclorg/valkey-container/.
 annotations:
   charts.openshift.io/name: Provides a Valkey database on RHEL imagestreams (experimental)
+  charts.openshift.io/provider: Red Hat
+  charts.openshift.io/providerType: redhat
 apiVersion: v2
 appVersion: 0.0.2
 kubeVersion: '>=1.20.0'

--- a/charts/redhat/redhat-valkey-persistent/src/Chart.yaml
+++ b/charts/redhat/redhat-valkey-persistent/src/Chart.yaml
@@ -5,11 +5,13 @@ description: |-
   NOTE: You must have persistent volumes available in your cluster to use this template.
 name: redhat-valkey-persistent
 tags: database,valkey
-version: 0.0.3
+version: 0.0.2
 annotations:
   charts.openshift.io/name: Red Hat Valkey in-memory data structure store, with persistent storage (experimental)
+  charts.openshift.io/provider: Red Hat
+  charts.openshift.io/providerType: redhat
 apiVersion: v2
-appVersion: 0.0.3
+appVersion: 0.0.2
 kubeVersion: '>=1.20.0'
 sources:
   - https://github.com/sclorg/helm-charts

--- a/charts/redhat/redhat-valkey-persistent/src/README.md
+++ b/charts/redhat/redhat-valkey-persistent/src/README.md
@@ -7,13 +7,14 @@ For more information about helm charts see the official [Helm Charts Documentati
 You need to have access to a cluster for each operation with OpenShift 4, like deploying and testing.
 
 ## Values
+
 Below is a table of each value used to configure this chart.
 
 | Value                   | Description                                                 | Default                     | Additional Information |
 |-------------------------|-------------------------------------------------------------|-----------------------------| ---------------------- |
 | `database_service_name` | The name of the OpenShift Service exposed for the database. | `valkey`                    | - |
 | `valkey_password`       | Password for the Valkey connection user.                    |                             | Expression like: `[a-zA-Z0-9]{16}` |
-| `valkey_version`        | Version of Valkey image to be used (6-el8, or latest).      | `6-el8`                     |  |
+| `valkey_version`        | Version of Valkey image to be used (6-el8, or latest).      | `8-el10`                     |  |
 | `namespace`             | The OpenShift Namespace where the ImageStream resides.      | `valkey-persistent-testing` | |
 | `memory_limit`          | Maximum amount of memory the container can use.             | `521Mi`                     |  |
 | `volume_capacity`       | Volume space available for data, e.g. 512Mi, 2Gi.           | `1Gi`                       |  |

--- a/tests/test_mysql_imagestreams.py
+++ b/tests/test_mysql_imagestreams.py
@@ -18,15 +18,14 @@ def helm_api(request):
 class TestHelmRHELMySQLImageStreams:
 
     @pytest.mark.parametrize(
-        "version,registry,expected",
+        "version,registry",
         [
-            ("8.4-el10", "registry.redhat.io/rhel10/mysql-84:latest", True),
-            ("8.4-el9", "registry.redhat.io/rhel9/mysql-84:latest", True),
-            ("8.0-el9", "registry.redhat.io/rhel9/mysql-80:latest", True),
-            ("8.0-el8", "registry.redhat.io/rhel8/mysql-80:latest", True),
+            ("8.4-el10", "registry.redhat.io/rhel10/mysql-84:latest"),
+            ("8.4-el9", "registry.redhat.io/rhel9/mysql-84:latest"),
+            ("8.4-el8", "registry.redhat.io/rhel8/mysql-84:latest"),
         ],
     )
-    def test_package_imagestream(self, helm_api, version, registry, expected):
+    def test_package_imagestream(self, helm_api, version, registry):
         assert helm_api.helm_package()
         assert helm_api.helm_installation()
-        assert helm_api.check_imagestreams(version=version, registry=registry) == expected
+        assert helm_api.check_imagestreams(version=version, registry=registry)

--- a/tests/test_mysql_template.py
+++ b/tests/test_mysql_template.py
@@ -24,8 +24,9 @@ class TestHelmMySQLDBPersistent:
     @pytest.mark.parametrize(
         "version",
         [
-            "8.0-el9",
-            "8.0-el8",
+            "8.4-el10",
+            "8.4-el9",
+            "8.4-el8",
         ],
     )
     def test_package_persistent(self, version):


### PR DESCRIPTION
This pull request deprecates MySQL-80 charts and MySQL-80 persistent storage

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated several charts and defaults to newer supported container versions, including MySQL, Redis, Ruby, and Valkey.
  * Added Red Hat provider metadata to multiple chart entries for clearer catalog display.

* **Bug Fixes**
  * Removed older MySQL image stream tags and narrowed version choices to currently supported releases.
  * Updated Redis and Ruby image stream references and documentation links to match newer versions.

* **Tests**
  * Adjusted automated checks to align with the updated MySQL image and version set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->